### PR TITLE
Fix typo in Events V1 trigger events doc

### DIFF
--- a/docs/events-API-v1/02-Trigger-Events.md
+++ b/docs/events-API-v1/02-Trigger-Events.md
@@ -75,7 +75,7 @@ title: Trigger Event
 ```
 <!--
 type: tab
-title: Acknowledge EVent
+title: Acknowledge Event
 -->
 
 ```json


### PR DESCRIPTION
## Description

 - Fixes a typo in the Events V1 trigger events docs

## Before Merging!

 - [ ] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from DevFoundations and from Community.
