### PR TITLE
Add PagerDuty CLI to the list of Tools and Samples

### DIFF
--- a/docs/tool-libraries/02-API-Tools-and-Code-Samples.md
+++ b/docs/tool-libraries/02-API-Tools-and-Code-Samples.md
@@ -11,9 +11,12 @@ Looking for ways to improve your workflow, or for inspiration and creative ways 
 > PagerDuty does not endorse or provide technical support for any API libraries or tools created and maintained by our user community.
 
 ## PagerDuty-Samples on GitHub
-[PagerDuty-Samples](https://github.com/PagerDuty-Samples/) is a collection of sample apps and examples for working with the PagerDuty API and platform. This is a place where  you'll find helpful projects that will explain how to do common tasks using common languages.
+[PagerDuty-Samples](https://github.com/PagerDuty-Samples/) is a collection of sample apps and examples for working with the PagerDuty API and platform. This is a place where you'll find helpful projects that will explain how to do common tasks using common languages.
 
 Please create a post in our [Developer forums](https://community.pagerduty.com/forum/c/developer) if you have any requests for future samples.
+
+## PagerDuty CLI
+[PagerDuty CLI](https://github.com/martindstone/pagerduty-cli/wiki/PagerDuty-CLI-User-Guide) is a command-line interface for PagerDuty. It's intended to be easy to install and use, and good at common tasks for both administrators and responders. It uses the PagerDuty REST API to communicate with PagerDuty. It’s implemented in TypeScript and Node.js, using the wonderful oclif library.
 
 ## Get Involved
 


### PR DESCRIPTION
## Description

 - I'd like to add PagerDuty CLI to the list of Tools and Code Samples

## Jira Ticket

 - No Jira ticket

## Before Merging!

 - [ ] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from DevFoundations and from Community.
