### PR TITLE
fix link to root cert in webhooks doc

### DIFF
--- a/docs/webhooks/03-Mutual-TLS.md
+++ b/docs/webhooks/03-Mutual-TLS.md
@@ -21,7 +21,7 @@ These steps assume you already have server authentication setup.
 
 In general, there are five steps needed to turn on client authentication for your server:
 
-1. Download the PEM version of the [DigiCert Global Root CA](https://www.websecurity.symantec.com/content/dam/websitesecurity/support/digicert/symantec/root/DigiCert_Global_Root_CA.pem) certificate.
+1. Download the PEM version of the [DigiCert Global Root CA](https://cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem) certificate.
 2. Turn on client certificate verification.
 Specify the CA certificate from 1 as trusted.
 3. Set the verification depth to 2 since our PagerDuty certificate is actually signed by the [DigiCert SHA2 Secure Server CA](https://dl.cacerts.digicert.com/DigiCertSHA2SecureServerCA.crt) which is an intermediate CA under DigiCert Global Root CA.

--- a/docs/webhooks/03-Mutual-TLS.md
+++ b/docs/webhooks/03-Mutual-TLS.md
@@ -23,7 +23,7 @@ In general, there are five steps needed to turn on client authentication for you
 
 1. Download the PEM version of the [DigiCert Global Root CA](https://cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem) certificate.
 2. Turn on client certificate verification.
-Specify the CA certificate from 1 as trusted.
+Specify the CA certificate from step 1 as trusted.
 3. Set the verification depth to 2 since our PagerDuty certificate is actually signed by the [DigiCert SHA2 Secure Server CA](https://dl.cacerts.digicert.com/DigiCertSHA2SecureServerCA.crt) which is an intermediate CA under DigiCert Global Root CA.
 4. Verify the client certificate is actually from PagerDuty by inspecting its Subject Domain Name.
 


### PR DESCRIPTION
## Description

 - In the [*Mutual TLS*](https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTky-mutual-tls) Webhooks doc, the link to the DigiCert Global Root CA is no longer accessible via https; this PR fixes that by linking to the PEM version of the cert as hosted by DigiCert.
 
 Current link leads here:
<img width="1177" alt="Screen Shot 2022-03-22 at 09 29 32" src="https://user-images.githubusercontent.com/34467850/159580609-35f8d2ff-6d31-4a98-82b2-4ae34642c63d.png">

## Jira Ticket

 - [T2D2-17](https://pagerduty.atlassian.net/browse/T2D2-17)

## Before Merging!

 - [ ] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from DevFoundations and from Community.
