### PR TITLE
DEVI-859 - Webhook Safelist IP changes

### DIFF
--- a/docs/webhooks/02-Behavior.md
+++ b/docs/webhooks/02-Behavior.md
@@ -77,7 +77,7 @@ PagerDuty's [v3 webhooks](../../docs/webhooks/01-Overview.md) are sent with a si
 
 ### IP Safelists
 
-You can configure your network or server to only accept inbound connections from certain IP addresses. See our [knowledge base article](https://support.pagerduty.com/docs/whitelisting-ips#section-webhooks) for information on obtaining the list of IPs webhooks may come from.  (Previously called IP whitelisting, [see why we changed the name here.](https://twitter.com/secnerdette/status/898314208097427457))
+You can configure your network or server to only accept inbound connections from certain IP addresses. See our [Webhook IPs page](../../docs/webhooks/11-Webhook-IPs.md) for information on obtaining the list of IPs webhooks may come from.  (Previously called IP whitelisting, [see why we changed the name here.](https://twitter.com/secnerdette/status/898314208097427457))
 
 ### Basic Authentication
 

--- a/docs/webhooks/11-Webhook-IPs.md
+++ b/docs/webhooks/11-Webhook-IPs.md
@@ -1,0 +1,52 @@
+---
+tags: [webhooks]
+---
+> Notice: This safelist of IP addresses will take effect April 28th, 2022 - 14:00 UTC
+
+# Webhook IPs
+
+This page lists the IP addresses that PagerDuty uses to send webhooks in each of our service regions.
+
+The full list of IP addresses that our webhook notifications may come from is:
+
+### US Service Region ([download](https://developer.pagerduty.com/ip-safelists/webhooks-us-service-region.txt))
+
+    44.242.69.192
+    52.89.71.166
+    54.213.187.133
+    35.86.21.47
+    52.88.94.18
+    44.238.89.29
+    54.241.68.46
+    54.176.72.216
+    54.177.81.67
+    13.56.49.27
+    34.210.57.30
+    34.210.242.134
+    52.34.208.156
+    34.202.21.89
+    34.239.229.93
+    34.231.45.166
+
+
+### EU Service Region ([download](https://developer.pagerduty.com/ip-safelists/webhooks-eu-service-region.txt))
+
+    18.192.91.93
+    18.158.120.237
+    18.194.177.30
+    18.158.199.216
+    3.126.25.87
+    18.197.187.16
+    54.76.3.62
+    54.170.2.90
+    52.213.188.110
+    54.195.179.238
+    34.250.91.200
+    54.76.225.71
+
+
+Until April 28th, 2022 - the [`/webhook_ips`](https://support.pagerduty.com/docs/safelist-ips#webhooks) programmatic endpoint is the authoritative source
+
+After April 28th, 2022 - the [`/webhook_ips`](https://support.pagerduty.com/docs/safelist-ips#webhooks) endpoint will no longer be updated, and this page should be used for all safelist updates.
+
+If you want total continuity in your firewall, you will need to safelist both sets of ip addresses some time before April 28th, 2022.

--- a/toc.json
+++ b/toc.json
@@ -268,6 +268,11 @@
           "type": "item",
           "title": "Public Certificates",
           "uri": "docs/webhooks/08-Certificates.md"
+        },
+        {
+          "type": "item",
+          "title": "Webhook IPs",
+          "uri": "docs/webhooks/11-Webhook-IPs.md"
         }
       ]
     },


### PR DESCRIPTION
## Description

 - Add a page with the new EIP/NAT Gateway Fixed IPs that squids will use to deliver Generic Webhooks
 - requires https://github.com/PagerDuty/developer-site/pull/642

## Jira Ticket

 - [DEVI-859](https://pagerduty.atlassian.net/browse/DEVI-859)

## Before Merging!

 - [ ] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from DevFoundations and from Community.
![6aptyu](https://user-images.githubusercontent.com/4094538/160871184-e5ae781a-0545-4952-9c19-029b09224f21.jpg)

