### PR TITLE
Update public documentation and API contracts to note the event transform fanout limit

### DIFF
--- a/docs/app-integration-development/07-Writing-App-Event-Transformers.md
+++ b/docs/app-integration-development/07-Writing-App-Event-Transformers.md
@@ -85,6 +85,11 @@ Signature: `PD.emitEventsV2([pagerduty_events_v2_object])`
 
 `PD.emitEventsV2` is used to emit an event or multiple events into the PagerDuty ecosystem
 
+PagerDuty imposes a limit on the number of events emitted by the `PD.emitEventsV2` method that will be processed.
+Though the number of invocations of the `PD.emitEventsV2` method is unconstrained, only the first 40 events emitted will be processed. Any events emitted in excess of the 40 event limit will be dropped and a single event will be generated indicating that the 40 event fanout limit was exceeded.
+
+When an event triggers a custom event transform emits many events through the use of `PD.emitEventsV2`, the emitted events are said to be fanout events method may be used to emit many events, PagerDuty imposes a limit on the number of 
+
 ### PagerDuty Events v2 Object
 The PagerDuty Events v2 object is in the [Events API v2 format](../../docs/events-API-v2/02-Trigger-Events.md).
 

--- a/docs/app-integration-development/07-Writing-App-Event-Transformers.md
+++ b/docs/app-integration-development/07-Writing-App-Event-Transformers.md
@@ -88,8 +88,6 @@ Signature: `PD.emitEventsV2([pagerduty_events_v2_object])`
 PagerDuty imposes a limit on the number of events emitted by the `PD.emitEventsV2` method that will be processed.
 Though the number of invocations of the `PD.emitEventsV2` method is unconstrained, only the first 40 events emitted will be processed. Any events emitted in excess of the 40 event limit will be dropped and a single event will be generated indicating that the 40 event fanout limit was exceeded.
 
-When an event triggers a custom event transform emits many events through the use of `PD.emitEventsV2`, the emitted events are said to be fanout events method may be used to emit many events, PagerDuty imposes a limit on the number of 
-
 ### PagerDuty Events v2 Object
 The PagerDuty Events v2 object is in the [Events API v2 format](../../docs/events-API-v2/02-Trigger-Events.md).
 

--- a/docs/app-integration-development/07-Writing-App-Event-Transformers.md
+++ b/docs/app-integration-development/07-Writing-App-Event-Transformers.md
@@ -86,7 +86,7 @@ Signature: `PD.emitEventsV2([pagerduty_events_v2_object])`
 `PD.emitEventsV2` is used to emit an event or multiple events into the PagerDuty ecosystem
 
 PagerDuty imposes a limit on the number of events emitted by the `PD.emitEventsV2` method that will be processed.
-Though the number of invocations of the `PD.emitEventsV2` method is unconstrained, only the first 40 events emitted will be processed. Any events emitted in excess of the 40 event limit will be dropped and a single event will be generated indicating that the 40 event fanout limit was exceeded.
+Though the `PD.emitEventsV2` method may be invoked any number of times, only the first 40 events emitted will be processed. Any events emitted in excess of the 40 event limit will be dropped and a single event will be generated indicating that the 40 event fanout limit was exceeded.
 
 ### PagerDuty Events v2 Object
 The PagerDuty Events v2 object is in the [Events API v2 format](../../docs/events-API-v2/02-Trigger-Events.md).

--- a/docs/app-integration-development/07-Writing-App-Event-Transformers.md
+++ b/docs/app-integration-development/07-Writing-App-Event-Transformers.md
@@ -83,7 +83,10 @@ Example:
 #### PD.emitEventsV2
 Signature: `PD.emitEventsV2([pagerduty_events_v2_object])`
 
-`PD.emitEventsV2` is used to emit an event or multiple events into the PagerDuty ecosystem
+`PD.emitEventsV2` is used to emit an event or multiple events into the PagerDuty ecosystem.
+  * Each invocation of `PD.emitEventsV2` emits one additional event to the set of events that the incoming event is being transformed into.
+  * For example, two invocations of `PD.emitEventsV2` would mean the incoming event is transformed into two events.
+  * An incoming event can be transformed into one or more events, but no more than 40.
 
 PagerDuty imposes a limit on the number of events emitted by the `PD.emitEventsV2` method that will be processed.
 Though the `PD.emitEventsV2` method may be invoked any number of times, only the first 40 events emitted will be processed. Any events emitted in excess of the 40 event limit will be dropped and a single event will be generated indicating that the 40 event fanout limit was exceeded.

--- a/docs/app-integration-development/07-Writing-App-Event-Transformers.md
+++ b/docs/app-integration-development/07-Writing-App-Event-Transformers.md
@@ -89,7 +89,8 @@ Signature: `PD.emitEventsV2([pagerduty_events_v2_object])`
   * An incoming event can be transformed into one or more events, but no more than 40.
 
 PagerDuty imposes a limit on the number of events emitted by the `PD.emitEventsV2` method that will be processed.
-Though the `PD.emitEventsV2` method may be invoked any number of times, only the first 40 events emitted will be processed. Any events emitted in excess of the 40 event limit will be dropped and a single event will be generated indicating that the 40 event fanout limit was exceeded.
+Though the `PD.emitEventsV2` method may be invoked any number of times, only the first 40 events emitted will be processed.
+Any events emitted in excess of the 40 event limit will be dropped and a single event will be generated saying "Event {{incoming event ID}} was transformed into {{total count}} fanout events. The first 40 were successfully processed. The remaining {{excess count}} excess fanout events were dropped."
 
 ### PagerDuty Events v2 Object
 The PagerDuty Events v2 object is in the [Events API v2 format](../../docs/events-API-v2/02-Trigger-Events.md).

--- a/docs/events-API-v1/03-Custom-Event-Transformer.md
+++ b/docs/events-API-v1/03-Custom-Event-Transformer.md
@@ -71,6 +71,10 @@ Example: `PD.fail(“Failed to parse event”)`
 #### PD.emitGenericEvents
   * `PD.emitGenericEvents` is used to emit an event or multiple events into the PagerDuty ecosystem
   * Signature: `PD.emitGenericEvents([the_pagerduty_payload])`
+  * PagerDuty imposes a limit on the number of events emitted by the `PD.emitGenericEvents` method that will be processed.
+    * Though the number of invocations of the `PD.emitGenericEvents` method is unconstrained, only the first 40 events emitted will be processed.
+    * Any events emitted in excess of the 40 event limit will be dropped and a single event will be generated indicating that the 40 event fanout limit was exceeded.
+
 
 
 ### The PagerDuty Payload

--- a/docs/events-API-v1/03-Custom-Event-Transformer.md
+++ b/docs/events-API-v1/03-Custom-Event-Transformer.md
@@ -69,7 +69,10 @@ Examples:
 Example: `PD.fail(“Failed to parse event”)`
 
 #### PD.emitGenericEvents
-  * `PD.emitGenericEvents` is used to emit an event or multiple events into the PagerDuty ecosystem
+  * `PD.emitGenericEvents` is used to emit an event or multiple events into the PagerDuty ecosystem.
+    * Each invocation of `PD.emitGenericEvents` emits one additional event to the set of events that the incoming event is being transformed into.
+    * For example, two invocations of `PD.emitGenericEvents` would mean the incoming event is transformed into two events.
+    * An incoming event can be transformed into one or more events, but no more than 40.
   * Signature: `PD.emitGenericEvents([the_pagerduty_payload])`
   * PagerDuty imposes a limit on the number of events emitted by the `PD.emitGenericEvents` method that will be processed.
     * Though the `PD.emitGenericEvents` method may be invoked any number of times, only the first 40 events emitted will be processed.

--- a/docs/events-API-v1/03-Custom-Event-Transformer.md
+++ b/docs/events-API-v1/03-Custom-Event-Transformer.md
@@ -76,7 +76,8 @@ Example: `PD.fail(“Failed to parse event”)`
   * Signature: `PD.emitGenericEvents([the_pagerduty_payload])`
   * PagerDuty imposes a limit on the number of events emitted by the `PD.emitGenericEvents` method that will be processed.
     * Though the `PD.emitGenericEvents` method may be invoked any number of times, only the first 40 events emitted will be processed.
-    * Any events emitted in excess of the 40 event limit will be dropped and a single event will be generated indicating that the 40 event fanout limit was exceeded.
+    * Any events emitted in excess of the 40 event limit will be dropped and a single event will be generated saying "Event {{incoming event ID}} was transformed into {{total count}} fanout events. The first 40 were successfully processed. The remaining {{excess count}} excess fanout events were dropped."
+
 
 
 

--- a/docs/events-API-v1/03-Custom-Event-Transformer.md
+++ b/docs/events-API-v1/03-Custom-Event-Transformer.md
@@ -72,7 +72,7 @@ Example: `PD.fail(“Failed to parse event”)`
   * `PD.emitGenericEvents` is used to emit an event or multiple events into the PagerDuty ecosystem
   * Signature: `PD.emitGenericEvents([the_pagerduty_payload])`
   * PagerDuty imposes a limit on the number of events emitted by the `PD.emitGenericEvents` method that will be processed.
-    * Though the number of invocations of the `PD.emitGenericEvents` method is unconstrained, only the first 40 events emitted will be processed.
+    * Though the `PD.emitGenericEvents` method may be invoked any number of times, only the first 40 events emitted will be processed.
     * Any events emitted in excess of the 40 event limit will be dropped and a single event will be generated indicating that the 40 event fanout limit was exceeded.
 
 


### PR DESCRIPTION
## Description

 - Documenting newly imposed event transform fanout limit on PD.emitEventsV2 and PD.emitGenericEvents methods

## Jira Ticket

 - [Update public documentation and API contracts to note the event transform fanout limit](https://pagerduty.atlassian.net/browse/ING-930)

## Before Merging!

 - [x] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [x] Ensure there is a review from DevFoundations and from Community.
