### PR TITLE
Update `pagerduty` gem entry in 01-Client-Libraries.md to indicate Events v2 support

### DIFF
--- a/docs/tool-libraries/01-Client-Libraries.md
+++ b/docs/tool-libraries/01-Client-Libraries.md
@@ -19,7 +19,7 @@ Want to get started using PagerDuty APIs quickly and easily? PagerDuty creates, 
 | PagerDuty Event Client (Gradle) | Java | [comodal/pagerduty-client](https://github.com/comodal/pagerduty-client) | Events v2 | Community |
 | PHP PagerDuty Events | PHP | [adilbaig/pagerduty](https://github.com/adilbaig/pagerduty) | Events v2 | Community |
 | PagerDuty::Connection | Ruby | [technicalpickles/pager_duty-connection](https://github.com/technicalpickles/pager_duty-connection) | REST | Community |
-| pagerduty gem | Ruby | [envato/pagerduty](https://github.com/envato/pagerduty) | Events v1 | Community |
+| pagerduty gem | Ruby | [envato/pagerduty](https://github.com/envato/pagerduty) | Events v1, Events v2 | Community |
 
 
 ## Get Involved


### PR DESCRIPTION
the `pagerduty` gem added support for Events v2  on 2020-04-20 with the [v3.0.0](https://github.com/envato/pagerduty/tree/v3.0.0) release.

## Description

 - Update the `pagerduty` gem entry to indicate that it supports Events v2 in addition to Events v1.

## Jira Ticket

 - Ref a Jira Ticket if it exists.

## Before Merging!

 - [ ] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from DevFoundations and from Community.
