### PR TITLE
[AF-915] Move things to identity dot pagerduty dot com

### DIFF
--- a/docs/app-integration-development/08-OAuth-2-Functionality.md
+++ b/docs/app-integration-development/08-OAuth-2-Functionality.md
@@ -60,8 +60,8 @@ PagerDuty uses ID Tokens [as defined by the OpenID specification][openid] to sec
 
  URL Name           | URL  | Description
 ----------------|------|------------
- Public Key URL | https://app.pagerduty.com/global/oauth/anonymous/jwks | Use the public key to verify that the token is unmodified and sent by PagerDuty
- Open ID Configuration | https://app.pagerduty.com/global/oauth/anonymous/.well-known/openid-configuration | Additional details on OpenID features supported by PagerDuty
+ Public Key URL | https://identity.pagerduty.com/global/oauth/anonymous/jwks | Use the public key to verify that the token is unmodified and sent by PagerDuty
+ Open ID Configuration | https://identity.pagerduty.com/global/oauth/anonymous/.well-known/openid-configuration | Additional details on OpenID features supported by PagerDuty
 
 The ID token will be returned with the access token on a successful call to `oauth/token`:
 
@@ -121,7 +121,7 @@ The claims included in the PagerDuty ID Token are described here in detail:
  `exp`           |  Expiry time, in a Unix timestamp
  `nbf`           |  Unix timestamp that identifies the time before the ID Token must NOT be accepted (not before)
  `jti`           |  Unique JWT ID
- `iss`           |  The principal/issuer that issued the ID Token. This should always be `https://app.pagerduty.com/global/oauth/anonymous`.
+ `iss`           |  The principal/issuer that issued the ID Token. This should always be `https://identity.pagerduty.com/global/oauth/anonymous`.
  `aud`           |  Intended reciever of the token (audience). For PagerDuty ID Tokens, this will include a URL specific to the account's service region, either `https://api.pagerduty.com` or `https://api.eu.pagerduty.com`, as well as the client ID.
  `sub`           |  Subject of the ID Token. For PagerDuty ID tokens, this can be used to uniquely identify the user that authorized the oauth client.
  `auth_time`     |  Time when authentication occurred, in a Unix timestamp
@@ -145,7 +145,7 @@ Here is a sample decrypted payload for a PagerDuty ID token:
   "exp": 1646086260,
   "nbf": 1646082660,
   "jti": "a9fd43a4-b037-4eeb-98b0-40542e3b98ff",
-  "iss": "https://app.pagerduty.com/global/oauth/anonymous",
+  "iss": "https://identity.pagerduty.com/global/oauth/anonymous",
   "aud": [
     "https://api.pagerduty.com",
     "90b153bf-cfeb-4837-8b6a-864b7ff85656"
@@ -171,7 +171,7 @@ Here is a sample decrypted payload for a PagerDuty ID token:
 
 The signature is used to verify that the message still has its original integrity and hasn't been tampered with and is sent from a trusted issuer.
 
-You can find the public key that PagerDuty uses to sign the token at the following URL: https://app.pagerduty.com/global/oauth/anonymous/jwks Please note however that the signing key could be rotated at any time, so we would recommend fetching the signing key from PagerDuty on each use instead of storing it locally.
+You can find the public key that PagerDuty uses to sign the token at the following URL: https://identity.pagerduty.com/global/oauth/anonymous/jwks Please note however that the signing key could be rotated at any time, so we would recommend fetching the signing key from PagerDuty on each use instead of storing it locally.
 
 This signature is created using the hash algorithm from the header, and to verify a token, you must do the following:
 
@@ -201,7 +201,7 @@ function verifyAndExtractIdTokenPayload(oauthTokenResponseJson) {
   const { idToken, domain, jwtIssuer } = oauthTokenResponseJson;
 
   return new Promise((resolve, reject) => {
-    https.get('https://app.pagerduty.com/global/oauth/anonymous/jwks', (jwksResponse) => {
+    https.get('https://identity.pagerduty.com/global/oauth/anonymous/jwks', (jwksResponse) => {
       let jwksData = '';
 
       jwksResponse.on('data', (chunk) => {

--- a/docs/app-integration-development/09-OAuth-2-Auth-Code-Grant.md
+++ b/docs/app-integration-development/09-OAuth-2-Auth-Code-Grant.md
@@ -15,8 +15,8 @@ PagerDuty supports OAuth 2.0’s [Authorization Code Grant](https://tools.ietf.o
 
 |||
 |-|-|
-|Authorization Endpoint|`https://app.pagerduty.com/oauth/authorize`|
-|Token Endpoint        |`https://app.pagerduty.com/oauth/token`|
+|Authorization Endpoint|`https://identity.pagerduty.com/oauth/authorize`|
+|Token Endpoint        |`https://identity.pagerduty.com/oauth/token`|
 
 
 The following parameters will also be used in your requests or returned in the response:
@@ -37,7 +37,7 @@ The following parameters will also be used in your requests or returned in the r
 Send a GET request to authorization endpoint with query parameters set for `client_id`, `redirect_uri` and `scope`, as defined in the app, and `response_type=code`
 
 ```
-GET https://app.pagerduty.com/oauth/authorize?client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&scope={SCOPE}&response_type=code
+GET https://identity.pagerduty.com/oauth/authorize?client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&scope={SCOPE}&response_type=code
 ```
 
 ### Authorized Requests
@@ -60,7 +60,7 @@ If the user denies authorization, PagerDuty will redirect to the specified URI w
 To exchange the authorization code for an access token, send a POST request to the token endpoint. The authorization code has a time to live of 30 seconds, and your POST request must be received within that time. The body of the request should include the following parameters: `client_id`, `client_secret`, `redirect_uri`, the `code` (authorization code) received from PagerDuty, and `grant_type=authorization_code`. The content type should be `application/x-form-urlencoded`.
 
 ```
-curl -X POST https://app.pagerduty.com/oauth/token \
+curl -X POST https://identity.pagerduty.com/oauth/token \
   -d "grant_type=authorization_code" \
   -d "client_id={CLIENT_ID}" \
   -d "client_secret={CLIENT_SECRET}" \

--- a/docs/app-integration-development/10-OAuth-2-PKCE.md
+++ b/docs/app-integration-development/10-OAuth-2-PKCE.md
@@ -13,8 +13,8 @@ The following endpoints conform to the OAuth 2.0 protocol for Authorization Code
 
 |||
 |-|-|
-|Authorization Endpoint|`https://app.pagerduty.com/oauth/authorize`|
-|Token Endpoint        |`https://app.pagerduty.com/oauth/token`|
+|Authorization Endpoint|`https://identity.pagerduty.com/oauth/authorize`|
+|Token Endpoint        |`https://identity.pagerduty.com/oauth/token`|
 
 ### What is PKCE?
 
@@ -42,7 +42,7 @@ The flow is initiated by sending a GET request to the Authorization Endpoint wit
 
 The user will be required to a) login with credentials and b) authorize the permissions requested by the client application.
 ```
-GET https://app.pagerduty.com/oauth/authorize?client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&scope={SCOPE}&response_type=code&code_challenge_method=S256&code_challenge
+GET https://identity.pagerduty.com/oauth/authorize?client_id={CLIENT_ID}&redirect_uri={REDIRECT_URI}&scope={SCOPE}&response_type=code&code_challenge_method=S256&code_challenge
 ```
 
 ## Obtaining an Access Grant : Leg 2 of 3
@@ -89,7 +89,7 @@ The authorization code has a time to live of 30 seconds, and your POST request m
 The body of the request should include the following parameters: `client_id`,  `redirect_uri`, the `code` (authorization code) received from PagerDuty, `grant_type=authorization_code`, and finally the `code_verifier` that was generated to create the code_challenge originally. The content-type should be `application/x-form-urlencoded`.
 
 ```
-curl -X POST https://app.pagerduty.com/oauth/token \
+curl -X POST https://identity.pagerduty.com/oauth/token \
   -d "grant_type=authorization_code"
   -d "client_id={CLIENT_ID}"
   -d "redirect_uri={REDIRECT_URI}"


### PR DESCRIPTION
[AF-915](https://pagerduty.atlassian.net/browse/AF-915) 

## Description
Now that https://pagerduty.atlassian.net/browse/AF-915 is finished we can move our docs to point to `identity.pagerduty.com`. 

## Before Merging!

 - [x] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [x] Ensure there is a review from DevFoundations and from Community.