### PR TITLE
Fix broken images on Global Event Rules API page

### DIFF
--- a/docs/REST-API/16-Global-Event-Rules-API.md
+++ b/docs/REST-API/16-Global-Event-Rules-API.md
@@ -86,7 +86,7 @@ None.
 ```
 
 ### Displayed in the UI
-![Screenshot of PagerDuty event rules interface](event-rules-interface.jpg)
+![Screenshot of PagerDuty event rules interface](../../assets/images/event-rules-interface.jpg)
 
 ### Other Fields
 
@@ -122,7 +122,7 @@ The `condition` field contains a list of conditions. The first field in the list
 
 #### Displayed in the UI
 
-![Screenshot of rule created in the PagerDuty event rules interface](created-event-rule.jpg)
+![Screenshot of rule created in the PagerDuty event rules interface](../../assets/images/created-event-rule.jpg)
 
 #### Operators
 


### PR DESCRIPTION
## Description

Fix the links to a few broken images on this page: https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTY1-global-event-rules-api

New relative paths are inspired by https://github.com/PagerDuty/developer-docs/blob/d2a0b4d2ddfe4c9abbbb68d0276b6b01b508e586/docs/app-integration-development/03-Register-an-App.md?plain=1#L17 which appears correctly here: https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTY5-register-an-app

I also searched the repo for other images, and all other images appear to have correct paths: https://cs.github.com/PagerDuty/developer-docs?q=%2F%5C.jpg%7C%5C.png%2F

## Jira Ticket

 - n/a – A quick fix in response to an internal report.

## Before Merging!

 - [x] :x: Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
     - I checked staging **but** images unrelated to this PR that appear **correctly** in production do **not** work on staging: https://developer-v2.pd-staging.com/docs/ZG9jOjExMDI5NTY5-register-an-app so apparently something is broken about asset serving in staging at the moment.
 - [ ] Ensure there is a review from DevFoundations and from Community.
