### PR TITLE
update certificate info after 2023 rotation

### DIFF
--- a/docs/webhooks/08-Certificates.md
+++ b/docs/webhooks/08-Certificates.md
@@ -6,26 +6,9 @@ tags: [webhooks]
 
 PagerDuty Webhooks provide client certificates when requested by a server (Mutual TLS).  
 
-It is our recommendation that customers configure their servers to trust the root certificate listed below. Customers choosing to rely on the PagerDuty client certificate are responsible for rotating to the new certificates at the appropriate time in order to avoid interrupted connectivity. PagerDuty webhook certificates are rotated yearly. The next certificate rotation will occur on **January 6th, 2023** for both the US and EU service regions. The [new certificates](#new-certificates) are provided below. 
+It is our recommendation that customers configure their servers to trust the root certificate listed below. Customers choosing to rely on the PagerDuty client certificate are responsible for rotating to the new certificates at the appropriate time in order to avoid interrupted connectivity. PagerDuty webhook certificates are rotated yearly. The most recent certificate rotation occurred on **January 6th, 2023** for both the US and EU service regions. The latest valid certificates are provided below. 
 
 ## Current Certificates
-
-#### US Service Region (webhooks.pagerduty.com)
-| Certificate Type                                                                                                             | Common Name                      | Valid Until         |
-|:-----------------------------------------------------------------------------------------------------------------------------|:---------------------------------|:--------------------|
-| PagerDuty Webhooks Certificate ([download](https://developer.pagerduty.com/certificates/2022_webhooks_pagerduty_com.pem))    | webhooks.pagerduty.com           | January 8th, 2023   |
-| Intermediate Certificate ([download](https://cacerts.digicert.com/DigiCertTLSRSASHA2562020CA1-1.crt.pem))                    | DigiCert TLS RSA SHA256 2020 CA1 | April 13th, 2031    |
-| Root Certificate ([download](https://cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem))                                     | DigiCert Global Root CA          | November 10th, 2031 |
-
-#### EU Service Region (webhooks.eu.pagerduty.com)
-
-| Certificate Type                                                                                                             | Common Name                         | Valid Until         |
-|:-----------------------------------------------------------------------------------------------------------------------------|:------------------------------------|:--------------------|
-| PagerDuty Webhooks Certificate ([download](https://developer.pagerduty.com/certificates/2022_webhooks_eu_pagerduty_com.pem)) | webhooks.eu.pagerduty.com           | January 8th, 2023   |
-| Intermediate Certificate ([download](https://cacerts.digicert.com/DigiCertTLSRSASHA2562020CA1-1.crt.pem))                    | DigiCert TLS RSA SHA256 2020 CA1    | April 13th, 2031    |
-| Root Certificate ([download](https://cacerts.digicert.com/DigiCertGlobalRootCA.crt.pem))                                     | DigiCert Global Root CA             | November 10th, 2031 |
-
-## New Certificates
 
 #### US Service Region (webhooks.pagerduty.com)
 | Certificate Type                                                                                                             | Common Name                      | Valid Until         |


### PR DESCRIPTION
## Description

- Webhook SSL certificates for `webhooks.pagerduty.com` and `webhooks.eu.pagerduty.com` were rotated on January 6th, 2023. This PR updates the public documentation with the latest information. 
- published to staging here: https://developer-v2.pd-staging.com/docs/28fa0c4c0c883-public-certificates

## Jira Ticket
https://pagerduty.atlassian.net/browse/DEVI-1417

## Before Merging!

 - [x] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from DevFoundations and from Community.
