### PR TITLE
ORCA-3847 fix exponent notation

### DIFF
--- a/docs/REST-API/18-PCL-Overview.md
+++ b/docs/REST-API/18-PCL-Overview.md
@@ -642,7 +642,7 @@ condition length | 2048 bytes | a single PCL condition cannot be longer than 204
 data length for matches operator | 65536 bytes (64K) | the left side of any of the matches operators will be truncated to 64K before the match operation executes
 levels of parenthesized nesting | 32 | a valid PCL condition will never go deeper than 32 levels of parentheses
 number of factors | 64 | only up to 64 factors combined with `and` or `or` are allowed
-literal integer range | 64-bit signed int | integers must fall between -2^<sup>63</sup> to 2<sup>63</sup> - 1
+literal integer range | 64-bit signed int | integers must fall between -2<sup>63</sup> to 2<sup>63</sup> - 1
 literal float range | 64-bit double precision float | floating point numbers follow the [IEEE 754 spec](https://en.wikipedia.org/wiki/IEEE_754)
 literal string length | 1024 bytes | a literal string can only be up to 1024 bytes
 number of path elements | 32 | a path can only contain up to 32 elements, e.g. `x.y.z[5]` has four elements

--- a/docs/REST-API/18-PCL-Overview.md
+++ b/docs/REST-API/18-PCL-Overview.md
@@ -642,7 +642,7 @@ condition length | 2048 bytes | a single PCL condition cannot be longer than 204
 data length for matches operator | 65536 bytes (64K) | the left side of any of the matches operators will be truncated to 64K before the match operation executes
 levels of parenthesized nesting | 32 | a valid PCL condition will never go deeper than 32 levels of parentheses
 number of factors | 64 | only up to 64 factors combined with `and` or `or` are allowed
-literal integer range | 64-bit signed int | integers must fall between $-2^{63}$ to $2^{63}-1$
+literal integer range | 64-bit signed int | integers must fall between -2^<sup>63</sup> to 2<sup>63</sup> - 1
 literal float range | 64-bit double precision float | floating point numbers follow the [IEEE 754 spec](https://en.wikipedia.org/wiki/IEEE_754)
 literal string length | 1024 bytes | a literal string can only be up to 1024 bytes
 number of path elements | 32 | a path can only contain up to 32 elements, e.g. `x.y.z[5]` has four elements


### PR DESCRIPTION
## Description

 - Noticed the changes added in https://github.com/PagerDuty/developer-docs/pull/50introduced rendered exponents wrong
<img width="950" alt="image" src="https://user-images.githubusercontent.com/12938545/212406672-9d45da9e-95f9-4c1f-87cd-716897c73e7c.png">

This changes fixes that

## Jira Ticket
https://pagerduty.atlassian.net/browse/ORCA-3847
## Before Merging!

 - [x ] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
<img width="852" alt="image" src="https://user-images.githubusercontent.com/12938545/212407271-65bdd1e0-6ac0-45c1-a254-3ad2d539fd15.png">

 - [ ] Ensure there is a review from DevFoundations and from Community.
