### PR TITLE
Update 10-OAuth-2-PKCE.md

### DIFF
--- a/docs/app-integration-development/10-OAuth-2-PKCE.md
+++ b/docs/app-integration-development/10-OAuth-2-PKCE.md
@@ -35,7 +35,7 @@ Required Parameters     | Description
 `redirect_uri`          | Registered with the app when OAuth 2.0 is added. PagerDuty will redirect here after a user grants or denies access to your app.
 `response_type`         | Specifies the response type based on OAuth 2.0 flow.<br/> Value must be set to `code`.
 `scope`                 | Specifies the scope being requested, must match what is configured on the OAuth application.
-`code_challenge`        | Base64 URL Encoded (without padding) string containing the SHA-256 digested form of the clients one-time random 128 byte verifier (also in Base64URLEncoded form without padding). See Javascript PKCE Example Algorithm below.
+`code_challenge`        | Base64 URL Encoded (without padding) string containing the SHA-256 digested form of the client's one-time random 93-byte verifier (also in Base64URLEncoded form without padding; not to exceed 128 bytes). See Javascript PKCE Example Algorithm below.
 `code_challenge_method` | Specifies that we are using PKCE SHA-256 Signature.<br/> Value must be set to `S256`.
 
 The flow is initiated by sending a GET request to the Authorization Endpoint with query parameters set for `client_id`, `redirect_uri`, `scope`, `response_type=code`, as well as the PKCE extension fields (`code_challenge` and `code_challenge_method`)


### PR DESCRIPTION
> Base64 URL Encoded (without padding) string containing the SHA-256 digested form of the clients one-time random 128 byte verifier (also in Base64URLEncoded form without padding). 

"clients" is incorrect, needs to be "client's"

"128 byte verifier" is incorrect - it's 128-byte *after* the verifier is base64-encoded. Actual verifier can be somewhere between 90 and 110 bytes; example code uses 93, so let's go with that.

## Description

 - Add a simple description of the changes

## Jira Ticket

 - Ref a Jira Ticket if it exists.

## Before Merging!

 - [ ] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from DevFoundations and from Community.
