### PR TITLE
[SCL-2142] Separate old and new REST API IPs in the safelist

### DIFF
--- a/docs/REST-API/19-REST-API-IPs.md
+++ b/docs/REST-API/19-REST-API-IPs.md
@@ -7,9 +7,11 @@ tags: [rest-api]
 
 This page lists the IP addresses that your system must be able to make outbound connections to on TCP port 443 to access our REST API in each of our service regions.
 
-The full list of IP addresses that our REST API may use is:
+The full list of IP addresses that our REST API may use is (separated between the old IP addresses and the new IP addresses):
 
 ### US Service Region
+
+### New IP Addresses
 
 download: [plain](https://developer.pagerduty.com/ip-safelists/rest-api-us-service-region) | [json](https://developer.pagerduty.com/ip-safelists/rest-api-us-service-region-json)
 
@@ -19,12 +21,19 @@ download: [plain](https://developer.pagerduty.com/ip-safelists/rest-api-us-servi
     34.212.97.30
     44.226.85.110
     52.24.121.31
+
+### Old IP Addresses
+
+download: [plain](https://developer.pagerduty.com/ip-safelists/rest-api-us-service-region-old) | [json](https://developer.pagerduty.com/ip-safelists/rest-api-us-service-region-json-old)
+
     44.227.224.80
     44.232.118.253
     35.162.7.45
 
 
 ### EU Service Region
+
+### New IP Addresses
 
 download: [plain](https://developer.pagerduty.com/ip-safelists/rest-api-eu-service-region) | [json](https://developer.pagerduty.com/ip-safelists/rest-api-eu-service-region-json)
 
@@ -34,6 +43,11 @@ download: [plain](https://developer.pagerduty.com/ip-safelists/rest-api-eu-servi
     3.79.82.135
     3.66.104.172
     3.73.115.116
+
+### Old IP Addresses
+
+download: [plain](https://developer.pagerduty.com/ip-safelists/rest-api-eu-service-region-old) | [json](https://developer.pagerduty.com/ip-safelists/rest-api-eu-service-region-json-old)
+
     18.158.168.35
     18.156.39.226
     18.157.174.159

--- a/docs/REST-API/19-REST-API-IPs.md
+++ b/docs/REST-API/19-REST-API-IPs.md
@@ -9,7 +9,7 @@ This page lists the IP addresses that your system must be able to make outbound 
 
 The full list of IP addresses that our REST API may use is (separated between the old IP addresses and the new IP addresses):
 
-### US Service Region
+## US Service Region
 
 ### New IP Addresses
 
@@ -31,7 +31,7 @@ download: [plain](https://developer.pagerduty.com/ip-safelists/rest-api-us-servi
     35.162.7.45
 
 
-### EU Service Region
+## EU Service Region
 
 ### New IP Addresses
 

--- a/docs/REST-API/19-REST-API-IPs.md
+++ b/docs/REST-API/19-REST-API-IPs.md
@@ -1,7 +1,7 @@
 ---
 tags: [rest-api]
 ---
-> Notice: This safelist of IP addresses will take effect October 25th, 2023
+> Notice: This safelist of IP addresses will take effect October 31st, 2023
 
 # REST API IPs
 
@@ -39,6 +39,6 @@ download: [plain](https://developer.pagerduty.com/ip-safelists/rest-api-eu-servi
     18.157.174.159
 
 
-After October 25th, 2023 - this page should be used for all safelist updates.
+After October 31st, 2023 - this page should be used for all safelist updates.
 
 Please review the list and update your firewall settings where necessary every 30 days to avoid any disruptions to your integrations with PagerDuty.


### PR DESCRIPTION
## Description

 - The date at which this safelist will take effect has changed from October 25 to October 31. The changes also separate old and new IP addresses to assure the customers that the old IPs can be used until October 31.
 - This PR requires https://github.com/PagerDuty/developer-site/pull/917 to be merged first

## Jira Ticket

 - JIRA ticket: https://pagerduty.atlassian.net/browse/SCL-2142

## Before Merging!

 - [x] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [x] Ensure there is a review from DevFoundations and from Community.
