### PR TITLE
[DEVI-1762] Early access REST API ratelimit docs.

### DIFF
--- a/docs/REST-API/04-Rate-Limits.md
+++ b/docs/REST-API/04-Rate-Limits.md
@@ -12,7 +12,7 @@ tags: [rest-api]
 > ### Upcoming Changes to REST API Rate Limits
 >
 > Previously this page read: _The rate limits on our REST API are currently 900 requests per minute across an entire organization._ The actual rate limits were closer to 900 requests per minute per token.
-> The behavior now described on this page is being rolled out during October and November 2023. See the [changelog](https://developer.pagerduty.com/api-reference/f1a95bb9397ba-changelog) for more details.
+> The behavior now described on this page is being rolled out during November and December 2023. See the [changelog](https://developer.pagerduty.com/api-reference/f1a95bb9397ba-changelog) for more details.
 
 ## What are the limits?
 

--- a/docs/REST-API/04-Rate-Limits.md
+++ b/docs/REST-API/04-Rate-Limits.md
@@ -1,0 +1,89 @@
+---
+tags: [rest-api]
+---
+
+# REST API Rate Limits
+
+<!-- theme: info -->
+> This page describes the rate limits for the PagerDuty REST API. The rate limits for the 
+> PagerDuty Events API are described [here](../../docs/events-API-v2/05-Rate-Limits.md).
+
+<!-- theme: warning -->
+> ### Upcoming Changes to REST API Rate Limits
+>
+> Previously this page read: _The rate limits on our REST API are currently 900 requests per minute across an entire organization._ The actual rate limits were closer to 900 requests per minute per token.
+> The behavior now described on this page is being rolled out during October and November 2023. See the [changelog](https://developer.pagerduty.com/api-reference/f1a95bb9397ba-changelog) for more details.
+
+## What are the limits?
+
+The PagerDuty REST API uses rate limits to provide a consistent experience for all of our customers. The limits depend on the type of authorization token being used. Each PagerDuty App has its own set of limits that are separate from both API keys and other apps.
+
+### Rate limits
+The limits described in this section apply to every request made to the PagerDuty REST API.
+
+**Account API Keys**
+
+Each Account API Key is allowed 960 requests per minute.
+
+**User API Keys**
+
+User API Keys act as a PagerDuty User and are limited as such. Each user is allowed 960 requests per minute across all of the user's API keys.
+
+**PagerDuty App - App OAuth Tokens**
+
+When a PagerDuty App [uses an app token](../../docs/app-integration-development/08-OAuth-Functionality.md) it is acting as the PagerDuty App. Each PagerDuty App is allowed 960 requests per minute against each PagerDuty Account it is authorized to access.
+
+**PagerDuty App - User OAuth Tokens**
+
+When a PagerDuty App [uses a user token](../../docs/app-integration-development/08-OAuth-Functionality.md) it is acting as the PagerDuty User. Each PagerDuty App is allowed 960 requests per minute per User it is authorized to act as.
+
+### Operation specific limits
+In a few exceptional circumstances, individual REST API operations may apply additional limits. If an endpoint applies additional limits; it will be noted in the [REST API](/api-reference/) documentation for that endpoint. The `ratelimit-` response headers described later in this document will provide information to the client about the current status of the limit and when it resets.
+
+## Working with limits
+How can your application gracefully interact with these limits? This section describes how our API informs client applications about limiting and covers some best practices.
+
+### Rate limit headers
+Requests that have been evaluated for rate limiting will include the following HTTP response headers:
+
+|Header Name|Description|
+|-|-|
+|`ratelimit-limit`|The allowed number of requests for the current time window.|
+|`ratelimit-remaining`|The remaining number requests in the current time window before limiting occurs.|
+|`ratelimit-reset`|The number of seconds until the limit is reset.|
+
+Note that when working with API endpoints that have operation specific limits; these headers will represent the limit that is closest to being reached.
+
+### Reaching the limit
+In the event that your application reaches a limit: the HTTP response code will be `429`, the rate limit headers will be present, and the response body will indicate that limiting has occurred:
+
+```bash
+HTTP/2 429 Too Many Requests
+
+date: Tue, 03 Oct 2023 16:46:39 GMT
+ratelimit-limit: 960
+ratelimit-remaining: 0
+ratelimit-reset: 20
+
+{
+  "error": {
+    "message": "Rate Limit Exceeded",
+    "code": 2020
+  }
+}
+```
+
+Note that there may be exceptional scenarios where an application receives a `429` response code _without_ the rate limit headers or the response body above.
+
+### Best practices
+
+#### Ensure your application is ready to handle being rate limited
+Update your application to slow down the rate of requests after receiving a 429 response code. For fine-grained control your application can make use of the `ratelimit-reset` header to wait the appropriate number of seconds before retrying.
+
+#### Avoid hitting rate limits
+These guidelines will help your application avoid hitting rate limits:
+* Make requests serially for a given authentication token.
+* Avoid excessive polling for changes whenever possible. Make use of available [Webhooks](../../docs/webhooks/01-Overview.md) to receive push updates to data.
+
+#### One "bot user" per application deployment
+If you use PagerDuty Users / User API Keys as "bot users" for applications; create a separate bot user for each deployment of the application (e.g. "Acme Production Bot User", "Acme Test Bot User", etc.). This will keep the limits for each deployment of the application separate.

--- a/docs/REST-API/14-Errors.md
+++ b/docs/REST-API/14-Errors.md
@@ -40,7 +40,7 @@ The HTTP response can be used to determine if the request was successful, and if
 | 403 | Forbidden | Caller is not authorized to view the requested resource. |
 | 404 | Not Found | The requested resource was not found. |
 | 408 | Request Timeout | The request took too long to process. Please try again. |
-| 429 | Too Many Requests | The caller is making requests too frequently. Wait a moment before making further requests and make them at a reduced rate. See [Rate Limiting](../../docs/REST-API/04-Rate-Limiting.md). |
+| 429 | Too Many Requests | The caller is making requests too frequently. Wait a moment before making further requests and make them at a reduced rate. See the [REST API Rate Limits](../../docs/REST-API/04-Rate-Limits.md) and [Events API Rate Limits](../../docs/events-API-v2/05-Rate-Limits.md) pages for more detail. |
 | 500 | Internal Server Error | Internal error occurred while processing request, likely due to transient issues. Please try again. **Tip:** We recommend adding retry logic to your client to automatically try your request again later. |
 
 ### PagerDuty Error Codes
@@ -89,6 +89,7 @@ This list of error codes is not exhaustive, but is representative of the kinds o
 | 2017 | Too Many Contact Method Actions |
 | 2018 | Access Denied: You may have lost access to this incident if it has been resolved |
 | 2019 | Product Limit Reached |
+| 2020 | Rate Limit Exceeded |
 | 2100 | Not Found |
 | 3001 | Invalid Schedule |
 | 3004 | <ul><li>Schedule Not Found</li><li>Unknown Schedule</li></ul> |

--- a/docs/REST-API/99-Rate-Limiting-23.md
+++ b/docs/REST-API/99-Rate-Limiting-23.md
@@ -1,0 +1,10 @@
+---
+tags: [rest-api]
+---
+
+# Upcoming REST API Rate Limits
+
+<!-- theme: info -->
+> ### Upcoming Changes to REST API Rate Limits
+>
+> This page has been moved to [REST API Rate Limits](../../docs/REST-API/04-Rate-Limits.md).

--- a/docs/events-API-v2/05-Rate-Limits.md
+++ b/docs/events-API-v2/05-Rate-Limits.md
@@ -1,19 +1,20 @@
 ---
-tags: [rest-api]
+tags: [events-API-v2, events-api-v1]
 ---
 
-# Rate Limiting
+# Events API Rate Limits
 
-## What are our limits?
-Our rate limits via the Events v2 API, there is a limit of approximately 120 calls/minute per integration key. The limit is calculated over a 60 second window looking back from the current time.
+<!-- theme: info -->
+> This page describes the rate limits for the PagerDuty Events API. The rate limits for the 
+> PagerDuty REST API are described [here](../../docs/REST-API/04-Rate-Limits.md).
 
-Our rate limits on our REST API is 900 events/min across an entire organization.
+## What are the limits?
+The PagerDuty Events API uses rate limits to provide a consistent experience for all of our customers. The Events v2 API has a limit of approximately 120 calls/minute per integration key. The limit is calculated over a 60 second window looking back from the current time. Account level limits are also applied to ensure reasonable use.
 
 ## The difference between an API call limit and an API rate limit
   A **call limit** is the number of times you can invoke an API within a certain time period. It is often a limit imposed purely by a SaaS vendor's business choice (pricing/packaging) rather than for technical reasons of capacity or fairness.
 
  A **rate limit** is one imposed by a vendor for reasons of fairness, so that one customer doesn’t overwhelm the vendor’s infrastructure with events or deny service to other customers.
-
 
 ## What happens when a customer reaches the Events API rate limit?
 The response to the API call will say `429 - Request Limit Exceeded` and PagerDuty will not ingest the event.
@@ -23,4 +24,3 @@ The response to the API call will say `429 - Request Limit Exceeded` and PagerDu
 - *Integrations* / *Service* - The rate limit applies per integration key.  An easy solution is to increase the number of integration keys used on a service (fan out).
 - *Services* - Another solution involves splitting a service into two or more.  This includes the added benefit of being more specific with service definitions.
 - In rare cases, engineering can raise the rate limit for Enterprise customers.  This is rarely done, but please reach out to your account manager for more details.
- 

--- a/toc.json
+++ b/toc.json
@@ -123,8 +123,8 @@
         },
         {
           "type": "item",
-          "title": "Rate Limiting",
-          "uri": "docs/REST-API/04-Rate-Limiting.md"
+          "title": "Rate Limits",
+          "uri": "docs/REST-API/04-Rate-Limits.md"
         },
         {
           "type": "item",
@@ -226,6 +226,11 @@
           "type": "item",
           "title": "Custom Change Event Transformer",
           "uri": "docs/events-API-v2/04-Custom-Change-Event-Transformer.md"
+        },
+        {
+          "type": "item",
+          "title": "Rate Limits",
+          "uri": "docs/events-API-v2/05-Rate-Limits.md"
         },
         {
           "type": "item",


### PR DESCRIPTION
## Description

- Splits the existing rate limiting documentation into separate pages for the Events API and REST API.
- Adds the initial documentation page for the upcoming changes to the REST API rate limits.
- See https://github.com/PagerDuty/captains-log/pull/1187 for the overall plan.


## Before Merging!

 - [x] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [x] Verify that updated links are working properly.
 - [x] Ensure there is a review from Dev Foundations and from Community.
