### PR TITLE
update role body to include `display_name`

### DIFF
--- a/docs/webhooks/20-Early-Access-Webhooks.md
+++ b/docs/webhooks/20-Early-Access-Webhooks.md
@@ -143,7 +143,6 @@ Depending on the `event.event_type`, of the webhook payload, the `event.data` fi
         "role": {
           "id": "P8PQO4R",
           "summary": "Role Display Name",
-          "name": "unique_role_name",
           "type": "role_reference"
         },
         "status": "active",

--- a/docs/webhooks/20-Early-Access-Webhooks.md
+++ b/docs/webhooks/20-Early-Access-Webhooks.md
@@ -143,6 +143,7 @@ Depending on the `event.event_type`, of the webhook payload, the `event.data` fi
         "role": {
           "id": "P8PQO4R",
           "summary": "test role",
+          "display_name": "test role",
           "type": "role_reference"
         },
         "status": "active",

--- a/docs/webhooks/20-Early-Access-Webhooks.md
+++ b/docs/webhooks/20-Early-Access-Webhooks.md
@@ -142,8 +142,8 @@ Depending on the `event.event_type`, of the webhook payload, the `event.data` fi
         "old_assignee": null,
         "role": {
           "id": "P8PQO4R",
-          "summary": "test role",
-          "display_name": "test role",
+          "summary": "Role Display Name",
+          "name": "unique_role_name",
           "type": "role_reference"
         },
         "status": "active",


### PR DESCRIPTION
## Description
This PR updates the role assignment webhook documentation to show the changes to the `role.summary` field to show that it now allows for spaces and capital letters since it now holds `roles.description` instead of `role.name`.
## Jira Ticket

 - [INCIDENTS-1590](https://pagerduty.atlassian.net/browse/INCIDENTS-1590)

## Before Merging!

 - [x] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [x] Ensure there is a review from DevFoundations and from Community.


[INCIDENTS-1590]: https://pagerduty.atlassian.net/browse/INCIDENTS-1590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ