### PR TITLE
SHAF-238 - update devdocs owning Team

### DIFF
--- a/.buildkite/stg-pipeline.yml
+++ b/.buildkite/stg-pipeline.yml
@@ -16,4 +16,4 @@ pd-meta: # Used by Buildkite Pipeline Manager (https://github.com/PagerDuty/buil
   name: "Developer Docs Staging"
   teams:
     - "All"
-    - "Developer Foundations"
+    - "SHAF Shared"

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,4 +9,4 @@
 ## Before Merging!
 
  - [ ] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
- - [ ] Ensure there is a review from DevFoundations and from Community.
+ - [ ] Ensure there is a review from SHAF Shared and from Community.

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository has a staging environment so you can see the changes before push
 
 ### Ownership
 
-These docs are owned by the #dev-foundations team and they will review and deploy any changes made- simply ask them via Slack when you open a pull request.
+These docs are owned by the #shaf-shared team and they will review and deploy any changes made- simply ask them via Slack when you open a pull request.
 
 
 ## Markdown


### PR DESCRIPTION
## Description

 - Update owning team for Dev Docs

## Jira Ticket

 - [SHAF-238](https://pagerduty.atlassian.net/browse/SHAF-238)

## Before Merging!

 - [ ] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from DevFoundations and from Community.


[SHAF-238]: https://pagerduty.atlassian.net/browse/SHAF-238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ