### PR TITLE
Remove reference to old and new IP lists on REST API lPs page

### DIFF
--- a/docs/REST-API/19-REST-API-IPs.md
+++ b/docs/REST-API/19-REST-API-IPs.md
@@ -7,7 +7,7 @@ tags: [rest-api]
 
 This page lists the IP addresses that your system must be able to make outbound connections to on TCP port 443 to access our REST API in each of our service regions.
 
-The full list of IP addresses that our REST API may use is (separated between the old IP addresses and the new IP addresses):
+The full list of IP addresses that our REST API may use is:
 
 ## US Service Region
 


### PR DESCRIPTION
## Description

 - A few months ago, the REST API IPs page was updated to remove 2 lists of old IP addresses (one for each of the service regions). The page text still had a reference to the old and new lists, so I have removed that in this PR as it is no longer the case.

## Before Merging!

 - [x] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [x] Ensure there is a review from SHAF Shared and from Community.
