### PR TITLE
Clarify that the v3 Webhook `event.agent` can have a `null`

### DIFF
--- a/docs/webhooks/01-Overview.md
+++ b/docs/webhooks/01-Overview.md
@@ -97,7 +97,7 @@ Each webhook payload contains a single event object. This event object contains 
 | `event.event_type`    | String   | The type of the event. This usually provides a description of what happened (e.g. `incident.priority_updated`). |
 | `event.resource_type` | String   | The root resource type (leftmost part of the `event_type`) this event is about (currently `incident` or `service`). It can be different from the more specific `data.type` in the event payload.                                                    |
 | `event.occurred_at`   | DateTime | An ISO 8601 datetime indicating when the event occurred.                                                        |
-| `event.agent`         | Object or `null` | Indicates who or what initiated the event. |
+| `event.agent`         | Object or `null` | Indicates who or what initiated the event. A `null` value might indicate an event triggered via automation rather than a specific person. |
 | `event.client`        | Object   | Information about where the event was triggered.                                                                |
 | `event.data`          | Object   | Data specific to the `event_type` that occurred.                                                                |
 

--- a/docs/webhooks/01-Overview.md
+++ b/docs/webhooks/01-Overview.md
@@ -98,7 +98,7 @@ Each webhook payload contains a single event object. This event object contains 
 | `event.resource_type` | String   | The root resource type (leftmost part of the `event_type`) this event is about (currently `incident` or `service`). It can be different from the more specific `data.type` in the event payload.                                                    |
 | `event.occurred_at`   | DateTime | An ISO 8601 datetime indicating when the event occurred.                                                        |
 | `event.agent`         | a [Resource Reference](https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTYw-resource-references) or `null` | Indicates who or what initiated the event. A `null` value might indicate an event triggered via automation rather than a specific person. |
-| `event.client`        | Object   | Information about where the event was triggered.                                                                |
+| `event.client`        | Object or `null` | Information about where the event was triggered.                                                                |
 | `event.data`          | Object   | Data specific to the `event_type` that occurred.                                                                |
 
 An example webhook payload for an `incident.priority_updated` event is shown below.

--- a/docs/webhooks/01-Overview.md
+++ b/docs/webhooks/01-Overview.md
@@ -97,7 +97,7 @@ Each webhook payload contains a single event object. This event object contains 
 | `event.event_type`    | String   | The type of the event. This usually provides a description of what happened (e.g. `incident.priority_updated`). |
 | `event.resource_type` | String   | The root resource type (leftmost part of the `event_type`) this event is about (currently `incident` or `service`). It can be different from the more specific `data.type` in the event payload.                                                    |
 | `event.occurred_at`   | DateTime | An ISO 8601 datetime indicating when the event occurred.                                                        |
-| `event.agent`         | Object or `null` | Indicates who or what initiated the event. A `null` value might indicate an event triggered via automation rather than a specific person. |
+| `event.agent`         | a [Resource Reference](https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTYw-resource-references) or `null` | Indicates who or what initiated the event. A `null` value might indicate an event triggered via automation rather than a specific person. |
 | `event.client`        | Object   | Information about where the event was triggered.                                                                |
 | `event.data`          | Object   | Data specific to the `event_type` that occurred.                                                                |
 

--- a/docs/webhooks/01-Overview.md
+++ b/docs/webhooks/01-Overview.md
@@ -97,7 +97,7 @@ Each webhook payload contains a single event object. This event object contains 
 | `event.event_type`    | String   | The type of the event. This usually provides a description of what happened (e.g. `incident.priority_updated`). |
 | `event.resource_type` | String   | The root resource type (leftmost part of the `event_type`) this event is about (currently `incident` or `service`). It can be different from the more specific `data.type` in the event payload.                                                    |
 | `event.occurred_at`   | DateTime | An ISO 8601 datetime indicating when the event occurred.                                                        |
-| `event.agent`         | Object   | Indicates who or what initiated the event.                                                                      |
+| `event.agent`         | Object or `null` | Indicates who or what initiated the event. |
 | `event.client`        | Object   | Information about where the event was triggered.                                                                |
 | `event.data`          | Object   | Data specific to the `event_type` that occurred.                                                                |
 


### PR DESCRIPTION
## Description

Before this change [v3 Webhook Overview docs](https://developer.pagerduty.com/docs/db0fa8c8984fc-overview#webhook-payload) already implied that the `event.agent` can have a `null` value because it's demonstrated in the "example webhook payload for a service.updated event is shown below."

This PR makes the Webhook Payload documentation more clear via the following changes:

1. Specifies that the `event.agent` object is specifically a [Resource Reference](https://developer.pagerduty.com/docs/ZG9jOjExMDI5NTYw-resource-references).
2. Explicitly states that the `event.agent` object can have a `null` value.
3. Explicitly states that the `event.client` object can have a `null` value.

It's worth nothing that I have **not** done a comprehensive analysis of whether **other** Webhook `event` fields can also have `null` values.

## Jira Ticket

 - https://pagerduty.atlassian.net/browse/ORCA-5086

## Before Merging!

 - [x] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended. <br> <img width="1278" alt="Monosnap Mozilla Firefox 2024-12-13 12-28-26" src="https://github.com/user-attachments/assets/db1e4dc0-f646-466d-afe9-8eff16b81096" />
 - [ ] Ensure there is a review from SHAF Shared and from Community.
