### PR TITLE
AF-2038 - webhook cert rotation, update wording

### DIFF
--- a/docs/REST-API/01-Overview.md
+++ b/docs/REST-API/01-Overview.md
@@ -44,4 +44,4 @@ Connecting to the PagerDuty REST API requires using [TLS (Transport Layer Securi
 
 Currently, our REST API supports TLS protocol versions 1.2.
 
-Our server certificate is signed by DigiCert. Client systems will need to have the **DigiCert Global Root CA** certificate in their local trust store (this is often already the case). CA certificates, if needed, can be [obtained from DigiCert](https://www.digicert.com/digicert-root-certificates.htm).
+Our server certificate is issued and signed by DigiCert. Client systems will need to have an up-to-date certificate bundle that includes DigiCert root certificates in their local trust store. CA certificates, if needed, can be obtained directly [from DigiCert](https://www.digicert.com/digicert-root-certificates.htm).

--- a/docs/webhooks/08-Certificates.md
+++ b/docs/webhooks/08-Certificates.md
@@ -6,7 +6,7 @@ tags: [webhooks]
 
 PagerDuty Webhooks provide client certificates when requested by a server (Mutual TLS).  
 
-It is our recommendation that customers configure their servers to keep an up-to-date certificate bundle that includes DigiCert root certificates in their local trust store. Customers choosing to rely on the PagerDuty client certificate are responsible for rotating to the new certificates at the appropriate time in order to avoid interrupted connectivity. PagerDuty webhook client certificates are rotated yearly. The current certificates are provided below.
+We recommend that customers configure their servers to keep an up-to-date certificate bundle that includes DigiCert root certificates in their local trust store. Customers relying on the PagerDuty client certificate are responsible for rotating to the new certificates at the appropriate time to avoid interrupted connectivity. PagerDuty webhook client certificates are rotated yearly. The current certificates are provided below.
 
 #### Client Certificates
 Certificate | Common Name | Start Date | End Date | Download

--- a/docs/webhooks/08-Certificates.md
+++ b/docs/webhooks/08-Certificates.md
@@ -6,15 +6,14 @@ tags: [webhooks]
 
 PagerDuty Webhooks provide client certificates when requested by a server (Mutual TLS).  
 
-It is our recommendation that customers configure their servers to trust the root certificate listed below. Customers choosing to rely on the PagerDuty client certificate are responsible for rotating to the new certificates at the appropriate time in order to avoid interrupted connectivity. PagerDuty webhook client certificates are rotated yearly. The next certificate rotation will occur on **December 18th, 2024** for both the US and EU service regions. The current and upcoming certificates are provided below.
+It is our recommendation that customers configure their servers to keep an up-to-date certificate bundle that includes DigiCert root certificates in their local trust store. Customers choosing to rely on the PagerDuty client certificate are responsible for rotating to the new certificates at the appropriate time in order to avoid interrupted connectivity. PagerDuty webhook client certificates are rotated yearly. The current certificates are provided below.
 
 #### Client Certificates
 Certificate | Common Name | Start Date | End Date | Download
 ---------|----------|---------|---------|---------
- Upcoming US region certificate | webhooks.pagerduty.com | December 18th, 2024 | December 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_pagerduty_com.pem)
- Upcoming EU region certificate | webhooks.eu.pagerduty.com | December 18th, 2024 | December 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_eu_pagerduty_com.pem)
- Current US region certificate | webhooks.pagerduty.com | January 4th, 2024 | December 18th, 2024 | [link](https://developer.pagerduty.com/certificates/2024_webhooks_pagerduty_com.pem)
- Current EU region certificate | webhooks.eu.pagerduty.com | January 4th, 2024 | December 18th, 2024 | [link](https://developer.pagerduty.com/certificates/2024_webhooks_eu_pagerduty_com.pem)
+ US region certificate | webhooks.pagerduty.com | December 18th, 2024 | December 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_pagerduty_com.pem)
+ EU region certificate | webhooks.eu.pagerduty.com | December 18th, 2024 | December 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_eu_pagerduty_com.pem)
+
 
 #### Issuer Certificates
 Certificate Type | Common Name | Valid Until | Download

--- a/docs/webhooks/08-Certificates.md
+++ b/docs/webhooks/08-Certificates.md
@@ -11,8 +11,8 @@ We recommend that customers configure their servers to keep an up-to-date certif
 #### Client Certificates
 Certificate | Common Name | Start Date | End Date | Download
 ---------|----------|---------|---------|---------
- US region certificate | webhooks.pagerduty.com | December 18th, 2024 | December 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_pagerduty_com.pem)
- EU region certificate | webhooks.eu.pagerduty.com | December 18th, 2024 | December 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_eu_pagerduty_com.pem)
+ US region certificate | webhooks.pagerduty.com | December 18th, 2024 | November 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_pagerduty_com.pem)
+ EU region certificate | webhooks.eu.pagerduty.com | December 18th, 2024 | November 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_eu_pagerduty_com.pem)
 
 
 #### Issuer Certificates

--- a/docs/webhooks/11-Webhook-IPs.md
+++ b/docs/webhooks/11-Webhook-IPs.md
@@ -5,6 +5,7 @@ tags: [webhooks]
 # Webhook IPs
 
 This page lists the IP addresses that PagerDuty uses to send webhooks in each of our service regions.
+The full list of IP addresses that our webhook notifications may come from is:
 
 ### US Service Region
 

--- a/docs/webhooks/11-Webhook-IPs.md
+++ b/docs/webhooks/11-Webhook-IPs.md
@@ -1,13 +1,10 @@
 ---
 tags: [webhooks]
 ---
-> Notice: This safelist of IP addresses will take effect May 5th, 2022 - 14:00 UTC
 
 # Webhook IPs
 
 This page lists the IP addresses that PagerDuty uses to send webhooks in each of our service regions.
-
-The full list of IP addresses that our webhook notifications may come from is:
 
 ### US Service Region
 
@@ -44,10 +41,3 @@ download: [plain](https://developer.pagerduty.com/ip-safelists/webhooks-eu-servi
     54.195.179.238
     34.250.91.200
     54.76.225.71
-
-
-Until May 5th, 2022 - the [`/webhook_ips`](https://support.pagerduty.com/docs/safelist-ips#webhooks) programmatic endpoint is the authoritative source.
-
-After May 5th, 2022 - the [`/webhook_ips`](https://support.pagerduty.com/docs/safelist-ips#webhooks) endpoint will no longer be updated, and this page should be used for all safelist updates.
-
-If you want total continuity in your firewall, you will need to safelist both sets of ip addresses some time before May 5th, 2022.

--- a/docs/webhooks/11-Webhook-IPs.md
+++ b/docs/webhooks/11-Webhook-IPs.md
@@ -5,6 +5,7 @@ tags: [webhooks]
 # Webhook IPs
 
 This page lists the IP addresses that PagerDuty uses to send webhooks in each of our service regions.
+
 The full list of IP addresses that our webhook notifications may come from is:
 
 ### US Service Region


### PR DESCRIPTION
## [AF-2038 - Webhook Cert Rotation for Production](https://pagerduty.atlassian.net/browse/AF-2038)

Updates some wording throughout re: certs and webhooks.
- In `Overview.md`, we actually no longer use DigiCert Global Root CA as our cert's root issuer, it's now DigiCert Global Root G2. In any case, it's better to be more broad and provide a more industry standard recommendation to keep an up-to-date cert store.
- In `Certificates.md`, same as above. Also removes "upcoming certificates" since we have now rotated.
- In `Webhook-IPs.md`, removing some old references to an endpoint from 2022.