### PR TITLE
AF-2137 - Updates API Client Libraries Page

### DIFF
--- a/docs/tool-libraries/01-Client-Libraries.md
+++ b/docs/tool-libraries/01-Client-Libraries.md
@@ -13,17 +13,18 @@ Want to get started using PagerDuty APIs quickly and easily? PagerDuty creates, 
 | Project Name | Language | GitHub Repo Link | Works with | Supported by |
 |:-------------|:---------|:-----------------|:-----------|:-------------|
 | go-pagerduty | Golang | [PagerDuty/go-pagerduty](https://github.com/PagerDuty/go-pagerduty) | REST, Events v1, Events v2 | PagerDuty |
-| pdpyras | Python | [PagerDuty/pdpyras](https://github.com/PagerDuty/pdpyras) | REST, Events v2 | PagerDuty |
+| python-pagerduty | Python | [PagerDuty/python-pagerduty](https://github.com/PagerDuty/python-pagerduty) | REST, Events v2 | PagerDuty |
 | PDJS | JavaScript | [PagerDuty/PDJS](https://github.com/PagerDuty/PDJS) | REST, Events v2 | PagerDuty |
 | PagerDuty Events Client for Java | Java | [dikhan/pagerduty-client](https://github.com/dikhan/pagerduty-client) | Events v2 | Community |
 | PagerDuty Event Client (Gradle) | Java | [comodal/pagerduty-client](https://github.com/comodal/pagerduty-client) | Events v2 | Community |
 | PHP PagerDuty Events | PHP | [adilbaig/pagerduty](https://github.com/adilbaig/pagerduty) | Events v2 | Community |
 | PagerDuty::Connection | Ruby | [technicalpickles/pager_duty-connection](https://github.com/technicalpickles/pager_duty-connection) | REST | Community |
 | pagerduty gem | Ruby | [envato/pagerduty](https://github.com/envato/pagerduty) | Events v1 | Community |
+| PagerDuty Events Client for .NET | .NET | [Aldaviva/PagerDuty](https://github.com/Aldaviva/PagerDuty) | Events v2 | Community |
 
 
 ## Get Involved
 
-Have you built a library or other wrapper for any PagerDuty APIs? Let us know in our [Developer forums](https://community.pagerduty.com/forum/c/developer)! 
+Have you built a library or other wrapper for any PagerDuty APIs? Let us know in our [Developer forums](https://community.pagerduty.com/get-involved-16)! 
 
 We're always happy to add new projects to our directory. Please note that all submissions must support or rely on current, non-deprecated, public APIs to be included in the directory.


### PR DESCRIPTION
## Description

 - Replaces deprecated pdpyras with python-pagerduty - fixes #119 
 - Adds PagerDuty Events Client for .NET to the API libraries table - [discussion here](https://community.pagerduty.com/get-involved-16/net-client-library-for-events-api-v2-141)
 - Fixes broken link to the Get Involved section in the Community Forums - Jira Ticket AF-2137

## Jira Ticket

 - [AF-2137](https://pagerduty.atlassian.net/browse/AF-2137)


[AF-2137]: https://pagerduty.atlassian.net/browse/AF-2137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ