### PR TITLE
Fix wording under Authentication page

### DIFF
--- a/docs/REST-API/02-Authentication.md
+++ b/docs/REST-API/02-Authentication.md
@@ -10,7 +10,7 @@ tags: [rest-api]
 All REST API calls require authentication. In order to make successful requests to the REST API, you must provide a valid form of authorization.
 
 ### API Token Authentication
-The PagerDuty REST API supports authenticating via an account or user API token. Account API tokens have access to all of the data on an account, and can either be granted read-only access or full access to read, write, update, and delete. For PagerDuty accounts with [Advanced Permissions](https://support.pagerduty.com/docs/advanced-permissions), user API tokens have access to all of the data that the associated user account has access to.
+The PagerDuty REST API supports authenticating via an account or user API token. Account API tokens have access to all of the data on an account, can either be granted read-only access or full access to read, write, update, and delete, and are tied to the account rather than the user responsible for creating them. For PagerDuty accounts with [Advanced Permissions](https://support.pagerduty.com/docs/advanced-permissions), user API tokens have access to all of the data that the associated user account has access to.
 
 Only account administrators have the ability to [generate account API tokens](https://support.pagerduty.com/docs/using-the-api#section-generating-a-general-access-rest-api-key).
 

--- a/docs/REST-API/02-Authentication.md
+++ b/docs/REST-API/02-Authentication.md
@@ -10,7 +10,10 @@ tags: [rest-api]
 All REST API calls require authentication. In order to make successful requests to the REST API, you must provide a valid form of authorization.
 
 ### API Token Authentication
-The PagerDuty REST API supports authenticating via an account or user API token. Account API tokens have access to all of the data on an account, can either be granted read-only access or full access to read, write, update, and delete, and are tied to the account rather than the user responsible for creating them. For PagerDuty accounts with [Advanced Permissions](https://support.pagerduty.com/docs/advanced-permissions), user API tokens have access to all of the data that the associated user account has access to.
+The PagerDuty REST API supports authenticating via an account or user API token. 
+
+- Account API tokens have access to all of the data on an account, can either be granted read-only access or full access to read, write, update, and delete, and are tied to the account rather than the user that created them.  
+- User API tokens are available for PagerDuty accounts with [Advanced Permissions](https://support.pagerduty.com/docs/advanced-permissions), and these user API tokens have access to all of the data that the associated user account has access to.
 
 Only account administrators have the ability to [generate account API tokens](https://support.pagerduty.com/docs/using-the-api#section-generating-a-general-access-rest-api-key).
 


### PR DESCRIPTION
Change to emphasize that account API tokens (keys) are specifically tied to the account and not the user

## Description

 - Update the `02-Authentication.md` page based on follow-up actions from an incident.

## Jira Ticket

 - AUTH-2192

## Before Merging!

 - [x] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from SHAF Shared and from Community.
