### PR TITLE
Changed DigiCert root cert URI to working page

### DIFF
--- a/docs/REST-API/01-Overview.md
+++ b/docs/REST-API/01-Overview.md
@@ -44,4 +44,4 @@ Connecting to the PagerDuty REST API requires using [TLS (Transport Layer Securi
 
 Currently, our REST API supports TLS protocol versions 1.2.
 
-Our server certificate is issued and signed by DigiCert. Client systems will need to have an up-to-date certificate bundle that includes DigiCert root certificates in their local trust store. CA certificates, if needed, can be obtained directly [from DigiCert](https://www.digicert.com/digicert-root-certificates.htm).
+Our server certificate is issued and signed by DigiCert. Client systems will need to have an up-to-date certificate bundle that includes DigiCert root certificates in their local trust store. CA certificates, if needed, can be obtained directly [from DigiCert](https://www.digicert.com/kb/digicert-root-certificates.htm).


### PR DESCRIPTION
## Description

 - Changed DigiCert root cert URI to working page.  I'm guessing that DigiCert changed their web platform, which changed URIs, which that broke some links.

## Jira Ticket

 - NA

## Before Merging!

 - [ ] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from Dev Ecosystem and Public APIs and from Community.
