### PR TITLE
SOC-218: Promote service.custom_field_values.updated webhook to ga

### DIFF
--- a/docs/webhooks/01-Overview.md
+++ b/docs/webhooks/01-Overview.md
@@ -238,6 +238,7 @@ Outbound events are created when PagerDuty resources change in interesting ways.
 | incident.workflow.started             | `incident_workflow_instance` | Sent when an incident workflow starts.                                                    | `incident_workflows.read` |
 | incident.workflow.completed           | `incident_workflow_instance` | Sent when an incident workflow completes.                                                 | `incident_workflows.read` |
 | service.created                       | `service`                    | Sent when a service is created.                                                           | `services.read`           |
+| service.custom_field_values.updated   | `service_field_values`       | Sent when an service's custom fields values are updated.                                  | `services.read`           |
 | service.deleted                       | `service`                    | Sent when a service is deleted.                                                           | `services.read`           |
 | service.updated                       | `service`                    | Sent when a service is updated.                                                           | `services.read`           |
 
@@ -501,6 +502,51 @@ Depending on the `event.event_type`, of the webhook payload, the `event.data` fi
     }
   ],
   "type": "service"
+}
+```
+&nbsp;
+### service_field_values
+```json
+{
+  "service": {
+    "html_url": "https://acme.pd-staging.com/services/PY0TW31",
+    "id": "PY0TW31",
+    "self": "https://api.pd-staging.com/services/PY0TW31",
+    "summary": null,
+    "type": "service_reference"
+  },
+  "custom_fields": [
+    {
+      "data_type": "string",
+      "field_type": "multi_value",
+      "id": "P0CU101",
+      "name": "string_multi_example_1",
+      "type": "field_value",
+      "value": [
+        "1",
+        "2"
+      ]
+    },
+    {
+      "data_type": "string",
+      "field_type": "single_value",
+      "id": "P7DNIMB",
+      "name": "example_field",
+      "type": "field_value",
+      "value": "Some new value"
+    }
+  ],
+  "changed_custom_fields": [
+    {
+      "data_type": "string",
+      "field_type": "single_value",
+      "id": "P7DNIMB",
+      "name": "example_field",
+      "type": "field_value",
+      "value": "Some old value"
+    }
+  ],
+  "type": "service_field_values"
 }
 ```
 &nbsp;

--- a/docs/webhooks/20-Early-Access-Webhooks.md
+++ b/docs/webhooks/20-Early-Access-Webhooks.md
@@ -59,12 +59,6 @@ Sent when an incident task is completed.
 
 Sent when an incident role is assigned or unassigned.
 
-### service.custom_field_values.updated
-
-`data.type` is [`service_field_values`](#service_field_values)
-
-Sent when an service's custom fields values are updated.
-
 ## Event Data Types
 
 Depending on the `event.event_type`, of the webhook payload, the `event.data` field will contain one of the objects described in this section.
@@ -156,49 +150,4 @@ Depending on the `event.event_type`, of the webhook payload, the `event.data` fi
       }
     ]
   }
-```
-
-### service_field_values
-```json
-{
-  "service": {
-    "html_url": "https://acme.pd-staging.com/services/PY0TW31",
-    "id": "PY0TW31",
-    "self": "https://api.pd-staging.com/services/PY0TW31",
-    "summary": null,
-    "type": "service_reference"
-  },
-  "custom_fields": [
-    {
-      "data_type": "string",
-      "field_type": "multi_value",
-      "id": "P0CU101",
-      "name": "string_multi_example_1",
-      "type": "field_value",
-      "value": [
-        "1",
-        "2"
-      ]
-    },
-    {
-      "data_type": "string",
-      "field_type": "single_value",
-      "id": "P7DNIMB",
-      "name": "example_field",
-      "type": "field_value",
-      "value": "Some new value"
-    }
-  ],
-  "changed_custom_fields": [
-    {
-      "data_type": "string",
-      "field_type": "single_value",
-      "id": "P7DNIMB",
-      "name": "example_field",
-      "type": "field_value",
-      "value": "Some old value"
-    }
-  ],
-  "type": "service_field_values"
-}
 ```


### PR DESCRIPTION
## Description

As we are moving forward to rollout Custom Fields on Services to GA, we need also to promote the `service.custom_field_values.updated webhook` event to GA.

 - Promoted `service.custom_field_values.updated` webhook event to GA.

## Jira Ticket

 - [SOC-218](https://pagerduty.atlassian.net/browse/SOC-218)

## Risks

> [!WARNING]
>  **This PR must be merged after https://github.com/PagerDuty/webhook_composition_service/pull/813**

## Before Merging!

 - [ ] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from Dev Ecosystem and Public APIs and from Community.
