### PR TITLE
[INCIDENTS-2666] Added reopened_at to the V3 Webhooks incident docs.

### DIFF
--- a/docs/webhooks/01-Overview.md
+++ b/docs/webhooks/01-Overview.md
@@ -129,7 +129,7 @@ An example webhook payload for an `incident.priority_updated` event is shown bel
       "status": "triggered",
       "incident_key": "d3640fbd41094207a1c11e58e46b1662",
       "created_at": "2020-04-09T15:16:27Z",
-      "reopened_at": "2025-07-14T05:09:33Z",
+      "reopened_at": "2020-10-02T18:45:22Z",
       "title": "A little bump in the road",
       "service": {
         "html_url": "https://acme.pagerduty.com/services/PF9KMXH",
@@ -258,7 +258,7 @@ Depending on the `event.event_type`, of the webhook payload, the `event.data` fi
   "status": "triggered",
   "incident_key": "d3640fbd41094207a1c11e58e46b1662",
   "created_at": "2020-04-09T15:16:27Z",
-  "reopened_at": "2025-07-14T05:09:33Z",
+  "reopened_at": "2020-10-02T18:45:22Z",
   "title": "A little bump in the road",
   "incident_type": {
     "name": "major"

--- a/docs/webhooks/01-Overview.md
+++ b/docs/webhooks/01-Overview.md
@@ -129,6 +129,7 @@ An example webhook payload for an `incident.priority_updated` event is shown bel
       "status": "triggered",
       "incident_key": "d3640fbd41094207a1c11e58e46b1662",
       "created_at": "2020-04-09T15:16:27Z",
+      "reopened_at": "2025-07-14T05:09:33Z",
       "title": "A little bump in the road",
       "service": {
         "html_url": "https://acme.pagerduty.com/services/PF9KMXH",
@@ -257,6 +258,7 @@ Depending on the `event.event_type`, of the webhook payload, the `event.data` fi
   "status": "triggered",
   "incident_key": "d3640fbd41094207a1c11e58e46b1662",
   "created_at": "2020-04-09T15:16:27Z",
+  "reopened_at": "2025-07-14T05:09:33Z",
   "title": "A little bump in the road",
   "incident_type": {
     "name": "major"


### PR DESCRIPTION
~# DO NOT MERGE until we have confirmation from Product that this change has been communicated to the relevant customers.~
# August 18th - got approval from customer teams and provided communications about this change

## Description

 - Adds the `reopened_at` field to the incident event type in the V3 Webhook docs.

STAGING LINK WITH CHANGE: https://developer-v2.pd-staging.com/docs/webhooks-overview#incident

## Jira Ticket

 - [INCIDENTS-2666](https://pagerduty.atlassian.net/browse/INCIDENTS-2666)

## Before Merging!

 - [x] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from Dev Ecosystem and Public APIs and from Community.


[INCIDENTS-2666]: https://pagerduty.atlassian.net/browse/INCIDENTS-2666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ