### PR TITLE
DEVECO-430: Update client certificate validity dates in webhook documentation

### DIFF
--- a/docs/webhooks/08-Certificates.md
+++ b/docs/webhooks/08-Certificates.md
@@ -11,8 +11,8 @@ We recommend that customers configure their servers to keep an up-to-date certif
 #### Client Certificates
 Certificate | Common Name | Start Date | End Date | Download
 ---------|----------|---------|---------|---------
- US region certificate | webhooks.pagerduty.com | November 6th, 2025 | December 7th 2026 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_pagerduty_com.pem)
- EU region certificate | webhooks.eu.pagerduty.com | November 6th, 2025 | December 7th 2026 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_eu_pagerduty_com.pem)
+ US region certificate | webhooks.pagerduty.com | November 6th, 2025 | December 7th 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_pagerduty_com.pem)
+ EU region certificate | webhooks.eu.pagerduty.com | November 6th, 2025 | December 7th 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_eu_pagerduty_com.pem)
 
 #### Issuer Certificates
 Certificate Type | Common Name | Valid Until | Download

--- a/docs/webhooks/08-Certificates.md
+++ b/docs/webhooks/08-Certificates.md
@@ -6,13 +6,15 @@ tags: [webhooks]
 
 PagerDuty Webhooks provide client certificates when requested by a server (Mutual TLS).  
 
-It is our recommendation that customers configure their servers to trust the root certificate listed below. Customers choosing to rely on the PagerDuty client certificate are responsible for rotating to the new certificates at the appropriate time in order to avoid interrupted connectivity. PagerDuty webhook client certificates are rotated yearly. The next certificate rotation will occur on **December 9th, 2025** for both the US and EU service regions. The current and upcoming certificates are provided below.
+It is our recommendation that customers configure their servers to trust the root certificate listed below. Customers choosing to rely on the PagerDuty client certificate are responsible for rotating to the new certificates at the appropriate time in order to avoid interrupted connectivity. PagerDuty webhook client certificates are rotated yearly. The next certificate rotation will occur on **December 18th, 2024** for both the US and EU service regions. The current and upcoming certificates are provided below.
 
 #### Client Certificates
 Certificate | Common Name | Start Date | End Date | Download
 ---------|----------|---------|---------|---------
- US region certificate | webhooks.pagerduty.com | December 9th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_pagerduty_com.pem)
- EU region certificate | webhooks.eu.pagerduty.com | December 9th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_eu_pagerduty_com.pem)
+ Upcoming US region certificate | webhooks.pagerduty.com | December 9th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_pagerduty_com.pem)
+ Upcoming EU region certificate | webhooks.eu.pagerduty.com | December 9th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_eu_pagerduty_com.pem)
+ Current US region certificate | webhooks.pagerduty.com | December 18th, 2024 | December 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_pagerduty_com.pem)
+ Current EU region certificate | webhooks.eu.pagerduty.com | December 18th, 2024 | December 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_eu_pagerduty_com.pem)
 
 #### Issuer Certificates
 Certificate Type | Common Name | Valid Until | Download

--- a/docs/webhooks/08-Certificates.md
+++ b/docs/webhooks/08-Certificates.md
@@ -13,8 +13,8 @@ Certificate | Common Name | Start Date | End Date | Download
 ---------|----------|---------|---------|---------
  Upcoming US region certificate | webhooks.pagerduty.com | December 9th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_pagerduty_com.pem)
  Upcoming EU region certificate | webhooks.eu.pagerduty.com | December 9th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_eu_pagerduty_com.pem)
- Current US region certificate | webhooks.pagerduty.com | December 18th, 2024 | December 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_pagerduty_com.pem)
- Current EU region certificate | webhooks.eu.pagerduty.com | December 18th, 2024 | December 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_eu_pagerduty_com.pem)
+ Current US region certificate | webhooks.pagerduty.com | December 18th, 2024 | November 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_pagerduty_com.pem)
+ Current EU region certificate | webhooks.eu.pagerduty.com | December 18th, 2024 | November 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_eu_pagerduty_com.pem)
 
 #### Issuer Certificates
 Certificate Type | Common Name | Valid Until | Download

--- a/docs/webhooks/08-Certificates.md
+++ b/docs/webhooks/08-Certificates.md
@@ -6,13 +6,13 @@ tags: [webhooks]
 
 PagerDuty Webhooks provide client certificates when requested by a server (Mutual TLS).  
 
-It is our recommendation that customers configure their servers to trust the root certificate listed below. Customers choosing to rely on the PagerDuty client certificate are responsible for rotating to the new certificates at the appropriate time in order to avoid interrupted connectivity. PagerDuty webhook client certificates are rotated yearly. The next certificate rotation will occur on **December 9th, 2025** for both the US and EU service regions. The current and upcoming certificates are provided below.
+It is our recommendation that customers configure their servers to trust the root certificate listed below. Customers choosing to rely on the PagerDuty client certificate are responsible for rotating to the new certificates at the appropriate time in order to avoid interrupted connectivity. PagerDuty webhook client certificates are rotated yearly. The next certificate rotation will occur on **December 16th, 2025** for both the US and EU service regions. The current and upcoming certificates are provided below.
 
 #### Client Certificates
 Certificate | Common Name | Start Date | End Date | Download
 ---------|----------|---------|---------|---------
- Upcoming US region certificate | webhooks.pagerduty.com | December 9th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_pagerduty_com.pem)
- Upcoming EU region certificate | webhooks.eu.pagerduty.com | December 9th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_eu_pagerduty_com.pem)
+ Upcoming US region certificate | webhooks.pagerduty.com | December 16th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_pagerduty_com.pem)
+ Upcoming EU region certificate | webhooks.eu.pagerduty.com | December 16th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_eu_pagerduty_com.pem)
  Current US region certificate | webhooks.pagerduty.com | December 18th, 2024 | November 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_pagerduty_com.pem)
  Current EU region certificate | webhooks.eu.pagerduty.com | December 18th, 2024 | November 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_eu_pagerduty_com.pem)
 

--- a/docs/webhooks/08-Certificates.md
+++ b/docs/webhooks/08-Certificates.md
@@ -11,9 +11,8 @@ We recommend that customers configure their servers to keep an up-to-date certif
 #### Client Certificates
 Certificate | Common Name | Start Date | End Date | Download
 ---------|----------|---------|---------|---------
- US region certificate | webhooks.pagerduty.com | December 18th, 2024 | November 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_pagerduty_com.pem)
- EU region certificate | webhooks.eu.pagerduty.com | December 18th, 2024 | November 2025 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_eu_pagerduty_com.pem)
-
+ US region certificate | webhooks.pagerduty.com | November 6th, 2025 | December 7th 2026 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_pagerduty_com.pem)
+ EU region certificate | webhooks.eu.pagerduty.com | November 6th, 2025 | December 7th 2026 | [link](https://developer.pagerduty.com/certificates/2025_webhooks_eu_pagerduty_com.pem)
 
 #### Issuer Certificates
 Certificate Type | Common Name | Valid Until | Download

--- a/docs/webhooks/08-Certificates.md
+++ b/docs/webhooks/08-Certificates.md
@@ -6,7 +6,7 @@ tags: [webhooks]
 
 PagerDuty Webhooks provide client certificates when requested by a server (Mutual TLS).  
 
-It is our recommendation that customers configure their servers to trust the root certificate listed below. Customers choosing to rely on the PagerDuty client certificate are responsible for rotating to the new certificates at the appropriate time in order to avoid interrupted connectivity. PagerDuty webhook client certificates are rotated yearly. The next certificate rotation will occur on **December 18th, 2024** for both the US and EU service regions. The current and upcoming certificates are provided below.
+It is our recommendation that customers configure their servers to trust the root certificate listed below. Customers choosing to rely on the PagerDuty client certificate are responsible for rotating to the new certificates at the appropriate time in order to avoid interrupted connectivity. PagerDuty webhook client certificates are rotated yearly. The next certificate rotation will occur on **December 9th, 2025** for both the US and EU service regions. The current and upcoming certificates are provided below.
 
 #### Client Certificates
 Certificate | Common Name | Start Date | End Date | Download

--- a/docs/webhooks/08-Certificates.md
+++ b/docs/webhooks/08-Certificates.md
@@ -11,8 +11,8 @@ We recommend that customers configure their servers to keep an up-to-date certif
 #### Client Certificates
 Certificate | Common Name | Start Date | End Date | Download
 ---------|----------|---------|---------|---------
- US region certificate | webhooks.pagerduty.com | November 6th, 2025 | December 7th 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_pagerduty_com.pem)
- EU region certificate | webhooks.eu.pagerduty.com | November 6th, 2025 | December 7th 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_eu_pagerduty_com.pem)
+ US region certificate | webhooks.pagerduty.com | November 6th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_pagerduty_com.pem)
+ EU region certificate | webhooks.eu.pagerduty.com | November 6th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_eu_pagerduty_com.pem)
 
 #### Issuer Certificates
 Certificate Type | Common Name | Valid Until | Download

--- a/docs/webhooks/08-Certificates.md
+++ b/docs/webhooks/08-Certificates.md
@@ -6,13 +6,13 @@ tags: [webhooks]
 
 PagerDuty Webhooks provide client certificates when requested by a server (Mutual TLS).  
 
-We recommend that customers configure their servers to keep an up-to-date certificate bundle that includes DigiCert root certificates in their local trust store. Customers relying on the PagerDuty client certificate are responsible for rotating to the new certificates at the appropriate time to avoid interrupted connectivity. PagerDuty webhook client certificates are rotated yearly. The current certificates are provided below.
+It is our recommendation that customers configure their servers to trust the root certificate listed below. Customers choosing to rely on the PagerDuty client certificate are responsible for rotating to the new certificates at the appropriate time in order to avoid interrupted connectivity. PagerDuty webhook client certificates are rotated yearly. The next certificate rotation will occur on **December 9th, 2025** for both the US and EU service regions. The current and upcoming certificates are provided below.
 
 #### Client Certificates
 Certificate | Common Name | Start Date | End Date | Download
 ---------|----------|---------|---------|---------
- US region certificate | webhooks.pagerduty.com | November 6th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_pagerduty_com.pem)
- EU region certificate | webhooks.eu.pagerduty.com | November 6th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_eu_pagerduty_com.pem)
+ US region certificate | webhooks.pagerduty.com | December 9th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_pagerduty_com.pem)
+ EU region certificate | webhooks.eu.pagerduty.com | December 9th, 2025 | October 2026 | [link](https://developer.pagerduty.com/certificates/2026_webhooks_eu_pagerduty_com.pem)
 
 #### Issuer Certificates
 Certificate Type | Common Name | Valid Until | Download


### PR DESCRIPTION
## Description

https://pagerduty.atlassian.net/browse/DEVECO-430

This pull request updates the documentation for webhook client certificates to reflect the new validity periods for both the US and EU region certificates.

Documentation updates:

* Updated the start and end dates for the US and EU region webhook client certificates in `docs/webhooks/08-Certificates.md` to show the new validity window: November 6th, 2025 to October, 2026.

## Jira Ticket

 - Ref a Jira Ticket if it exists.

## Before Merging!

 - [ ] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from SHAF Shared and from Community.
