### PR TITLE
feat: [DEVECO-699] Move incident action invocations to GA

### DIFF
--- a/docs/webhooks/01-Overview.md
+++ b/docs/webhooks/01-Overview.md
@@ -236,6 +236,9 @@ Outbound events are created when PagerDuty resources change in interesting ways.
 | incident.status_update_published      | `incident_status_update`     | Sent when a status update is added to an incident.                                        | `incidents.read`          |
 | incident.triggered                    | `incident`                   | Sent when an incident is newly created/triggered.                                         | `incidents.read`          |
 | incident.unacknowledged               | `incident`                   | Sent when an incident is unacknowledged.                                                  | `incidents.read`          |
+| incident.action_invocation.created    | `incident_action_invocation` | Sent when an incident action invocation is created.                                       | `incidents.read`          |
+| incident.action_invocation.terminated | `incident_action_invocation` | Sent when an incident action invocation is terminated.                                    | `incidents.read`          |
+| incident.action_invocation.updated    | `incident_action_invocation` | Sent when an incident action invocation is updated.                                       | `incidents.read`          |
 | incident.workflow.started             | `incident_workflow_instance` | Sent when an incident workflow starts.                                                    | `incident_workflows.read` |
 | incident.workflow.completed           | `incident_workflow_instance` | Sent when an incident workflow completes.                                                 | `incident_workflows.read` |
 | service.created                       | `service`                    | Sent when a service is created.                                                           | `services.read`           |
@@ -553,6 +556,32 @@ Depending on the `event.event_type`, of the webhook payload, the `event.data` fi
 ```
 &nbsp;
 
+### incident_action_invocation
+
+```json
+{
+  "id": "01CELD6T9C2JS745I7CAK0LRRF",
+  "self": "https://api.pagerduty.com/automation/invocations/01CELD6T9C2JS745I7CAK0LRRF",
+  "html_url": "https://acme.pagerduty.com/rundeck-actions/actions/01CDYN0IRV4VG991K5FR73YNTW/invocations/01CELD6T9C2JS745I7CAK0LRRF/report",
+  "incident": {
+    "html_url": "https://acme.pagerduty.com/incidents/PBAZLIU",
+    "id": "PBAZLIU",
+    "self": "https://api.pagerduty.com/incidents/PBAZLIU",
+    "summary": "An Incident",
+    "type": "incident_reference"
+  },
+  "action": {
+    "html_url": "https://acme.pagerduty.com/rundeck-actions/actions/01CDYN0IRV4VG991K5FR73YNTW",
+    "id": "01CDYN0IRV4VG991K5FR73YNTW",
+    "self": "https://api.pagerduty.com/automation/actions/01CDYN0IRV4VG991K5FR73YNTW",
+    "summary": "A Helpful Action",
+    "type": "action_reference"
+  },
+  "state": "created",
+  "type": "incident_action_invocation"
+}
+```
+&nbsp;
 ## Early Access Events
 In addition to the events detailed on this page, we may occasionally have [Early Access events](20-Early-Access-Webhooks.md).
 These are subject to change at any moment, without notice.

--- a/docs/webhooks/20-Early-Access-Webhooks.md
+++ b/docs/webhooks/20-Early-Access-Webhooks.md
@@ -17,24 +17,6 @@ Early Access webhook events are provided here for informational purposes, but ar
 
 ## Event Types
 
-### incident.action_invocation.created
-
-`data.type` is [`incident_action_invocation`](#incident_action_invocation)
-
-Sent when an incident action invocation is created.
-
-### incident.action_invocation.updated
-
-`data.type` is [`incident_action_invocation`](#incident_action_invocation)
-
-Sent when an incident action invocation is updated.
-
-### incident.action_invocation.terminated
-
-`data.type` is [`incident_action_invocation`](#incident_action_invocation)
-
-Sent when an incident action invocation is terminated.
-
 ### incident.task.created
 
 `data.type` is [`incident_task`](#incident_task)
@@ -62,32 +44,6 @@ Sent when an incident role is assigned or unassigned.
 ## Event Data Types
 
 Depending on the `event.event_type`, of the webhook payload, the `event.data` field will contain one of the objects described in this section.
-
-### incident_action_invocation
-
-```json
-{
-  "id": "01CELD6T9C2JS745I7CAK0LRRF",
-  "self": "https://api.pagerduty.com/automation/invocations/01CELD6T9C2JS745I7CAK0LRRF",
-  "html_url": "https://acme.pagerduty.com/rundeck-actions/actions/01CDYN0IRV4VG991K5FR73YNTW/invocations/01CELD6T9C2JS745I7CAK0LRRF/report",
-  "incident": {
-    "html_url": "https://acme.pagerduty.com/incidents/PBAZLIU",
-    "id": "PBAZLIU",
-    "self": "https://api.pagerduty.com/incidents/PBAZLIU",
-    "summary": "An Incident",
-    "type": "incident_reference"
-  },
-  "action": {
-    "html_url": "https://acme.pagerduty.com/rundeck-actions/actions/01CDYN0IRV4VG991K5FR73YNTW",
-    "id": "01CDYN0IRV4VG991K5FR73YNTW",
-    "self": "https://api.pagerduty.com/automation/actions/01CDYN0IRV4VG991K5FR73YNTW",
-    "summary": "A Helpful Action",
-    "type": "action_reference"
-  },
-  "state": "created",
-  "type": "incident_action_invocation"
-}
-```
 
 ### incident_task
 


### PR DESCRIPTION
## Description

 - We moved the incident action invocations to GA as per [this PR](https://github.com/PagerDuty/webhook_composition_service/pull/956)

## Jira Ticket

 - https://pagerduty.atlassian.net/browse/DEVECO-699

## Before Merging!

 - [ ] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from Dev Ecosystem and Public APIs and from Community.
