### PR TITLE
SIG-4790: clarify contexts (v1) vs images/links (v2) on Trigger Events docs

### DIFF
--- a/docs/events-API-v1/02-Trigger-Events.md
+++ b/docs/events-API-v1/02-Trigger-Events.md
@@ -157,6 +157,10 @@ title: 403 Rate Limited
 
 ## Contexts
 
+<!-- theme:warning -->
+> ### Note
+> The `contexts` array is specific to **Events API v1**. Events API v2 does not accept a `contexts` array; it uses separate top-level [`images`](../../docs/events-API-v2/02-Trigger-Events.md#the-images-property) and [`links`](../../docs/events-API-v2/02-Trigger-Events.md#the-links-property) arrays instead. See [Send an Alert Event](../../docs/events-API-v2/02-Trigger-Events.md) for the v2 equivalents.
+
 The `contexts` field is a JSON array of informational assets that can be attached to the incident. Every element of the array is a JSON object referred to as a `context`.
 
 Every `context` must have a `type`. There are a few different types of contexts supported; the fields allowed and required depend on the context type.
@@ -179,7 +183,7 @@ The `image` type is used to attach images to an incident. Images must be served 
 Name   | Required | Description
 ------ | -------- | -----------
 `type` | Yes      | The type of context being attached to the incident. For image contexts, this must be `image`.
-`src`  | Yes      | The source (URL) of the image being attached to the incident. This image must be served via HTTPS.
+`src`  | Yes      | The source (URL) of the image being attached to the incident. This image must be served via HTTPS, must be reachable by PagerDuty, and must be a direct link to the image file itself (e.g. `https://example.com/chart.png`) — page URLs that merely contain an image will not render.
 `href` | No       | Optional link for the image.
 `alt`  | No       | Optional alternative text for the image.
 

--- a/docs/events-API-v2/02-Trigger-Events.md
+++ b/docs/events-API-v2/02-Trigger-Events.md
@@ -136,15 +136,19 @@ See the [Events API v2 Overview page](../../docs/events-API-v2/01-Overview.md#re
 
 These properties can be used to attach informational assets to the incident record. Each element of these arrays is an [object](../../docs/REST-API/06-Types.md#object).
 
+<!-- theme:warning -->
+> ### Note
+> Events API v2 uses the top-level `images` and `links` arrays described below to attach images and hyperlinks to an alert. It does **not** accept the `contexts` array — that is a [v1-only](../../docs/events-API-v1/02-Trigger-Events.md#contexts) field. If you send a `contexts` array to the v2 endpoint, it will be ignored.
+
 #### The `images` Property
 
 This property is used to attach images to the incident. Each object in the list has the following properties:
 
-| Name   | Required | Description                                                                                        |
-| ------ | -------- | -------------------------------------------------------------------------------------------------- |
-| `src`  | Yes      | The source (URL) of the image being attached to the incident. This image must be served via HTTPS. |
-| `href` | No       | Optional URL; makes the image a clickable link.                                                    |
-| `alt`  | No       | Optional alternative text for the image.                                                           |
+| Name   | Required | Description                                                                                                                                                                                                                                                                                                          |
+| ------ | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src`  | Yes      | The source (URL) of the image being attached to the incident. This image must be served via HTTPS, must be reachable by PagerDuty, and must be a direct link to the image file itself (e.g. `https://example.com/chart.png`) — page URLs that merely contain an image (e.g. `https://example.com/article`) will not render. |
+| `href` | No       | Optional URL; makes the image a clickable link.                                                                                                                                                                                                                                                                      |
+| `alt`  | No       | Optional alternative text for the image.                                                                                                                                                                                                                                                                             |
 
 #### The `links` Property
 


### PR DESCRIPTION
## Triage context

- Jira ticket: [SIG-4790](https://pagerduty.atlassian.net/browse/SIG-4790)
- Triage confidence: 0.95 (Tier 1)
- Generated by the `jira-triage` skill — please review carefully.

## What changed

Resolved cross-version ambiguity by adding callouts to both the V1 and V2 "Trigger Events" pages stating that `contexts` is V1-only and `images`/`links` are V2-only, and clarified that `src` URLs must point directly to an image file (not a containing page) — addressing the customer's exact confusion.

- `docs/events-API-v1/02-Trigger-Events.md` — Added a `theme:warning` callout at the top of the `## Contexts` section noting `contexts` is V1-specific and pointing to the V2 `images`/`links` properties. Expanded the `src` row to specify it must be a direct image URL reachable by PagerDuty.
- `docs/events-API-v2/02-Trigger-Events.md` — Added a `theme:warning` callout under "Context Properties" stating Events API v2 uses top-level `images`/`links` and does **not** accept `contexts` (with a deep link to the V1 `contexts` section). Expanded the `images.src` row similarly.

## Tests

Skipped — repo has no `package.json`, `Makefile`, prettier config, or markdownlint config. The only CI step is `.buildkite/stg-pipeline.yml`, which runs `@stoplight/cli push` to deploy content (no local validation step).

## Risk notes

- Both edited pages are public-facing customer documentation; reviewer should sanity-check the cross-reference anchors render correctly in Stoplight (`#the-images-property`, `#the-links-property` on the V2 page; `#contexts` on the V1 page).
- The V2 markdown table column widths were re-padded for the new longer `src` description; the rendered output will be unchanged, but a diff viewer will show all rows touched.
- Callout style (`<!-- theme:warning -->` + `> ### Note`) matches the existing convention used in `01-Overview.md` for both V1 and V2.

## Unresolved

- Ryan Bateman's Jira comment speculated the fix might belong in `PagerDuty/developer-site` (the Gatsby build target). The content-bearing markdown lives here in `developer-docs`, so edits were made here. If `developer-site` overrides or post-processes these pages, a parallel change may be needed.
- Did not edit the Stoplight API reference page at `https://developer.pagerduty.com/api-reference/368ae3d938c9e-send-an-event-to-pager-duty` (lives in a separate spec, not this repo).

[SIG-4790]: https://pagerduty.atlassian.net/browse/SIG-4790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ