### PR TITLE
[CORE-4832] Update TLS documentation to reflect TLS 1.3 support

### DIFF
--- a/docs/REST-API/01-Overview.md
+++ b/docs/REST-API/01-Overview.md
@@ -42,6 +42,6 @@ The following headers should be set as applicable when making HTTP requests to t
 ### TLS
 Connecting to the PagerDuty REST API requires using [TLS (Transport Layer Security)](https://en.wikipedia.org/wiki/Transport_Layer_Security).
 
-Currently, our REST API supports TLS protocol versions 1.2.
+Our REST API supports TLS protocol versions 1.2 and 1.3. We recommend using TLS 1.3 where supported, as it provides improved security and performance. TLS 1.2 remains fully supported for backwards compatibility.
 
 Our server certificate is issued and signed by DigiCert. Client systems will need to have an up-to-date certificate bundle that includes DigiCert root certificates in their local trust store. CA certificates, if needed, can be obtained directly [from DigiCert](https://www.digicert.com/digicert-root-certificates.htm).


### PR DESCRIPTION
## Summary

Updates the REST API Overview documentation to reflect TLS 1.3 support across all PagerDuty ingress endpoints.

## Changes

- `docs/REST-API/01-Overview.md`: Updated the TLS section to note that both TLS 1.2 and 1.3 are now supported, with a recommendation to use 1.3 where available.

## Why

As part of CORE-4832, TLS 1.3 is being rolled out across all ingress endpoints. This doc update ensures developers are aware of the expanded protocol support. TLS 1.2 remains fully supported for backwards compatibility — no client-side changes are required.