### PR TITLE
[DEVECO-886] Scoped Apps require PKCE now

### DIFF
--- a/docs/app-integration-development/08-OAuth-Functionality.md
+++ b/docs/app-integration-development/08-OAuth-Functionality.md
@@ -29,7 +29,7 @@ PagerDuty Apps with Classic User OAuth can be published for use with other Pager
 
 ### Scoped OAuth
 
-Scoped OAuth allows an application to act as the PagerDuty App itself by obtaining an app token using an OAuth 2.0 client credentials flow. Optionally, it can also act as a user after obtaining their authorization and consent. See [Obtaining an App OAuth Token](12-App-OAuth-Token.md), [Obtaining a User OAuth Token via Code Grant](09-User-OAuth-Token-Code-Grant.md) and [Obtaining a User OAuth Token via PKCE](10-User-OAuth-Token-PKCE.md) for the details of obtaining each type of token.
+Scoped OAuth allows an application to act as the PagerDuty App itself by obtaining an app token using an OAuth 2.0 client credentials flow. Optionally, it can also act as a user after obtaining their authorization and consent. See [Obtaining an App OAuth Token](12-App-OAuth-Token.md), [Obtaining a User OAuth Token via Code Grant](09-User-OAuth-Token-Code-Grant.md) and [Obtaining a User OAuth Token via PKCE](10-User-OAuth-Token-PKCE.md) for the details of obtaining each type of token. Please note that Scoped OAuth requires PKCE when obtaining tokens via Code Grant.
 
 The access available to an application using Scoped OAuth differs by token type:
 * With an app token, access is only limited by the scopes granted to the application. If the application has the `incidents.read` scope, it will be able to read all incidents on the account.


### PR DESCRIPTION
## Description

Per Security recommendation, https://github.com/PagerDuty/identity-proxy-service/pull/472/ makes PKCE required for Scoped OAuth apps going forward. This updates the documentation to mention that. The docs as a whole need a rewrite to accommodate Public Scoped Apps, so this is just a stop-gap sentence.

## Jira Ticket

 - [DEVECO-886](https://pagerduty.atlassian.net/browse/DEVECO-886)

## Before Merging!

 - [ ] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from Dev Ecosystem and Public APIs and from Community.


[DEVECO-886]: https://pagerduty.atlassian.net/browse/DEVECO-886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ