### PR TITLE
Remove local MCP server instructions and related references

### DIFF
--- a/docs/tool-libraries/01-Client-Libraries.md
+++ b/docs/tool-libraries/01-Client-Libraries.md
@@ -8,13 +8,13 @@ Want to get started using PagerDuty APIs quickly and easily? PagerDuty creates, 
 
 <!-- theme:info -->
 > ### Community Support
+>
 > PagerDuty does not endorse or provide technical support for any API libraries or tools created and maintained by our user community.
 
 | Project Name | Language | GitHub Repo Link | Works with | Supported by |
-|:-------------|:---------|:-----------------|:-----------|:-------------|
+| :------------- | :--------- | :----------------- | :----------- | :------------- |
 | go-pagerduty | Golang | [PagerDuty/go-pagerduty](https://github.com/PagerDuty/go-pagerduty) | REST, Events v1, Events v2 | PagerDuty |
 | python-pagerduty | Python | [PagerDuty/python-pagerduty](https://github.com/PagerDuty/python-pagerduty) | REST, Events v2 | PagerDuty |
-| pagerduty-mcp-server | Python | [Pagerduty/pagerduty-mcp-server](https://github.com/PagerDuty/pagerduty-mcp-server) | MCP | PagerDuty |
 | PDJS | JavaScript | [PagerDuty/PDJS](https://github.com/PagerDuty/PDJS) | REST, Events v2 | PagerDuty |
 | PagerDuty Events Client for Java | Java | [dikhan/pagerduty-client](https://github.com/dikhan/pagerduty-client) | Events v2 | Community |
 | PagerDuty Event Client (Gradle) | Java | [comodal/pagerduty-client](https://github.com/comodal/pagerduty-client) | Events v2 | Community |
@@ -22,7 +22,6 @@ Want to get started using PagerDuty APIs quickly and easily? PagerDuty creates, 
 | PagerDuty::Connection | Ruby | [technicalpickles/pager_duty-connection](https://github.com/technicalpickles/pager_duty-connection) | REST | Community |
 | pagerduty gem | Ruby | [envato/pagerduty](https://github.com/envato/pagerduty) | Events v1 | Community |
 | PagerDuty Events Client for .NET | .NET | [Aldaviva/PagerDuty](https://github.com/Aldaviva/PagerDuty) | Events v2 | Community |
-
 
 ## Get Involved
 

--- a/docs/tool-libraries/02-MCP.md
+++ b/docs/tool-libraries/02-MCP.md
@@ -7,14 +7,9 @@ performing complex interactions via an API, based on [JSON-RPC].
 
 PagerDuty's MCP server allows you to fetch and manage information in your PagerDuty account.
 
-## Local MCP Server
-
-If you'd like to run our MCP server yourself, you can check out the instructions [in GitHub][open-source MCP server].
-[Pull requests welcome][contributing]!
-
 ## Remote MCP Server
 
-You can also call our [Remote MCP Server][MCP API Reference]. This supports the same authentication methods as the REST API,
+You can call our [Remote MCP Server][MCP API Reference]. This supports the same authentication methods as the REST API,
 including API tokens and OAuth -- see our [authentication documentation] for more information.
 
 Key URLs:
@@ -22,7 +17,7 @@ Key URLs:
 - MCP Base URL: `https://mcp.pagerduty.com/mcp`
 - OAuth Metadata: `https://identity.pagerduty.com/global/oauth/anonymous/.well-known/openid-configuration`
 
-You can see the full list of tools by calling the `list/tools` method, or by browsing our [open-source MCP server].
+You can see the full list of tools by calling the `list/tools` method.
 
 ### Sample configuration
 
@@ -53,13 +48,10 @@ Here is a sample MCP configuration for Microsoft Visual Studio Code:
 ## Resources
 
 - [PagerDuty MCP API Reference][MCP API Reference]
-- [PagerDuty MCP Server Repository][open-source MCP server]
 - [Model Context Protocol] documentation from Anthropic
 - [JSON-RPC] documentation
 
   [Model Context Protocol]: https://modelcontextprotocol.io/specification/2025-06-18/basic
   [JSON-RPC]: https://www.jsonrpc.org/
-  [open-source MCP server]: https://github.com/PagerDuty/pagerduty-mcp-server?tab=readme-ov-file#pagerdutys-official-mcp-server
   [authentication documentation]: https://developer.pagerduty.com/docs/rest-api-v2/authentication/
   [MCP API Reference]: https://developer.pagerduty.com/api-reference/83ebf88243817-mcp-endpoint
-  [contributing]: https://github.com/PagerDuty/pagerduty-mcp-server/blob/main/CONTRIBUTING.md


### PR DESCRIPTION
## Description
Local MCP Server (open-source project) is now deprecated and the repo has been archived. We need to remove this out of our official developer docs.

## Before Merging!

 - [x] Check [staging environment](https://developer-v2.pd-staging.com/docs) to ensure changes look as intended.
 - [ ] Ensure there is a review from Dev Ecosystem and Public APIs and from Community.
